### PR TITLE
Exclude unnecessary files

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -35,12 +35,6 @@ if [ "$DOT_FILES" != "" ]; then
     exit 1
 fi
 
-PPK_FILES=`find $PLUGIN_DIR -name "*.ppk"`
-if [ "$PPK_FILES" != "" ]; then
-    echo "PLUGIN_DIR must not contain *.ppk files."
-    exit 1
-fi
-
 # Command
 if [ -x /bin/sed ]; then
     SED="/bin/sed"
@@ -67,7 +61,7 @@ PACKAGE_DIR=$BASE_DIR/tmp
 # And creating a content file by compressing the plug Directory
 CONTENTS_FILE=$PACKAGE_DIR/contents.zip
 cd $PLUGIN_DIR
-/usr/bin/zip -r $CONTENTS_FILE ./ >/dev/null
+/usr/bin/zip -x "*.ppk" -r "$CONTENTS_FILE" ./ >/dev/null
 
 # Create a signature and public key
 PUB_FILE=$PACKAGE_DIR/PUBKEY

--- a/package.sh
+++ b/package.sh
@@ -26,15 +26,6 @@ if [ ! -f "$PLUGIN_DIR/manifest.json" ]; then
     exit 1
 fi
 
-DOT_FILES=`find $PLUGIN_DIR -name ".*" | grep -v "/\.$"`
-if [ "$DOT_FILES" != "" ]; then
-    echo "PLUGIN_DIR must not contain dot files or directories."
-    for DOT_FILE in $DOT_FILES; do
-        echo $DOT_FILE
-    done
-    exit 1
-fi
-
 # Command
 if [ -x /bin/sed ]; then
     SED="/bin/sed"
@@ -61,7 +52,7 @@ PACKAGE_DIR=$BASE_DIR/tmp
 # And creating a content file by compressing the plug Directory
 CONTENTS_FILE=$PACKAGE_DIR/contents.zip
 cd $PLUGIN_DIR
-/usr/bin/zip -x "*.ppk" -r "$CONTENTS_FILE" ./ >/dev/null
+/usr/bin/zip -x "*/\.*" -x ".*" -x "*.ppk" -r "$CONTENTS_FILE" ./ >/dev/null
 
 # Create a signature and public key
 PUB_FILE=$PACKAGE_DIR/PUBKEY


### PR DESCRIPTION
On Mac, .DS_Store file created automatically when I access to the plugin dir.
It decreases development speed.

Also, developers may usually using git. If `.git` directory in the plugin dir, the script stop working.