### PR TITLE
Use https for map api URL and fix typo

### DIFF
--- a/examples/kyotenn/js/ma-zenrin_getLatLon.js
+++ b/examples/kyotenn/js/ma-zenrin_getLatLon.js
@@ -23,7 +23,7 @@ jQuery.noConflict();
     //--------Main------------------------------//
     kintone.events.on(['app.record.create.show', 'app.record.edit.show', 'app.record.index.edit.show'], function(event) {
         //SDK(JS)のロード
-        loadJS('http://'+ domain +'/cgi/loader.cgi?key=' + apikey + '&ver=2.0&api=zdcmap.js,serach.js&enc=SJIS');
+        loadJS('https://'+ domain +'/cgi/loader.cgi?key=' + apikey + '&ver=2.0&api=zdcmap.js,serach.js&enc=SJIS');
         //緯度、経度フィールドのdisabled
         var record = event.record;
         record[latField].disabled = true;

--- a/examples/kyotenn/js/ma-zenrin_getLatLon.js
+++ b/examples/kyotenn/js/ma-zenrin_getLatLon.js
@@ -23,7 +23,7 @@ jQuery.noConflict();
     //--------Main------------------------------//
     kintone.events.on(['app.record.create.show', 'app.record.edit.show', 'app.record.index.edit.show'], function(event) {
         //SDK(JS)のロード
-        loadJS('https://'+ domain +'/cgi/loader.cgi?key=' + apikey + '&ver=2.0&api=zdcmap.js,serach.js&enc=SJIS');
+        loadJS('https://'+ domain +'/cgi/loader.cgi?key=' + apikey + '&ver=2.0&api=zdcmap.js,search.js&enc=SJIS');
         //緯度、経度フィールドのdisabled
         var record = event.record;
         record[latField].disabled = true;


### PR DESCRIPTION
Firefox blocks `http://` URL if mixed content. So, use `https://` instead.
https://support.mozilla.org/en-US/kb/mixed-content-blocking-firefox

Fix typo to fix `TypeError: ZDC.Search.getLatLonByAddr is not a function`
`serach` => `search`

