### PR TITLE
新デザイン版　条件書式プラグインアップデート対応(v3)

### DIFF
--- a/examples/conditionformat2/css/51-current-default.css
+++ b/examples/conditionformat2/css/51-current-default.css
@@ -12,6 +12,10 @@
   line-height: 1.5;
 }
 
+:lang(us) *[class|="kintoneplugin"] {
+  font-family: 'HelveticaNeueW02-45Ligh', Arial, 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
+}
+
 :lang(ja) *[class|="kintoneplugin"] {
   font-family: 'メイリオ', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
 }
@@ -20,15 +24,11 @@
   font-family: '微软雅黑', 'Microsoft YaHei', '新宋体', NSimSun, STHeiti, Hei, 'Heiti SC', sans-serif;
 }
 
-:lang(us) *[class|="kintoneplugin"] {
-  font-family: 'HelveticaNeueW02-45Ligh', Arial, 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
-}
-
-/* メッセージのスタイル */
+/*Alert message*/
 /*
 <div class="kintoneplugin-alert">
-  <p>メッセージのスタイル、<br>メッセージのスタイル</p>
-  <p>メッセージのスタイル</p>
+  <p>Alert message、<br>Alert message</p>
+  <p>Alert message</p>
 </div>
 */
 .kintoneplugin-alert {
@@ -40,19 +40,19 @@
   color: #f6f6f6;
 }
 
-/* 設定項目の行 */
+/* Row for the settings　*/
 /*
-<div class="kintoneplugin-row">設定項目の行 1</div>
-<div class="kintoneplugin-row">設定項目の行 2</div>
+<div class="kintoneplugin-row">Settings 1</div>
+<div class="kintoneplugin-row">Settings 2</div>
 */
 .kintoneplugin-row {
   margin-bottom: 24px;
 }
 
-/* 設定項目の見出し */
-/* ラベル */
+/* Title for settings*/
+/* Labels */
 /*
-<div class="kintoneplugin-label">設定項目の見出し</div>
+<div class="kintoneplugin-label">Title</div>
 */
 .kintoneplugin-label {
   margin-bottom: 8px;
@@ -62,7 +62,7 @@
 /* 設定項目の見出し */
 /* 項目 */
 /*
-<div class="kintoneplugin-label">設定項目の見出し</div>
+<div class="kintoneplugin-title">設定項目の見出し</div>
 */
 .kintoneplugin-title {
   margin-bottom: 8px;
@@ -79,15 +79,15 @@
   color: #888;
 }
 
-/* 必須項目 */
+/* Required settings*/
 /*
-<div class="kintoneplugin-label">必須項目の見出し<span class="kintoneplugin-require">*</span></div>
+<div class="kintoneplugin-label">Title<span class="kintoneplugin-require">*</span></div>
 */
 .kintoneplugin-require {
   color: #c09853;
 }
 
-/* テキストボックス */
+/* Input (text box) */
 /*
 <div class="kintoneplugin-input-outer">
   <input class="kintoneplugin-input-text" type="text">
@@ -119,13 +119,13 @@
   color: #000;
 }
 
-/* チェックボックス */
-/* IE8では親要素に .lt-ie9 の指定が必要 */
+/* Check box */
+/* For IE8, specify .lt-ie9 for the parent. */
 /*
-<div class="kintoneplugin-input-checkbox"><span class="kintoneplugin-input-checkbox-item"><input type="checkbox" name="checkbox" value="0" id="checkbox-0" checked=""><label for="checkbox-0">チェックボックスA</label></span></div>
-<div class="kintoneplugin-input-checkbox"><span class="kintoneplugin-input-checkbox-item"><input type="checkbox" name="checkbox" value="1" id="checkbox-1"><label for="checkbox-1">チェックボックスB</label></span></div>
-<div class="kintoneplugin-input-checkbox"><span class="kintoneplugin-input-checkbox-item"><input type="checkbox" name="checkbox" value="2" id="checkbox-2" checked="" disabled=""><label for="checkbox-2">チェックボックスC</label></span></div>
-<div class="kintoneplugin-input-checkbox"><span class="kintoneplugin-input-checkbox-item"><input type="checkbox" name="checkbox" value="3" id="checkbox-3" disabled=""><label for="checkbox-3">チェックボックスD</label></span></div>
+<div class="kintoneplugin-input-checkbox"><span class="kintoneplugin-input-checkbox-item"><input type="checkbox" name="checkbox" value="0" id="checkbox-0" checked=""><label for="checkbox-0">Checkbox A</label></span></div>
+<div class="kintoneplugin-input-checkbox"><span class="kintoneplugin-input-checkbox-item"><input type="checkbox" name="checkbox" value="1" id="checkbox-1"><label for="checkbox-1">Checkbox B</label></span></div>
+<div class="kintoneplugin-input-checkbox"><span class="kintoneplugin-input-checkbox-item"><input type="checkbox" name="checkbox" value="2" id="checkbox-2" checked="" disabled=""><label for="checkbox-2">Checkbox C</label></span></div>
+<div class="kintoneplugin-input-checkbox"><span class="kintoneplugin-input-checkbox-item"><input type="checkbox" name="checkbox" value="3" id="checkbox-3" disabled=""><label for="checkbox-3">Checkbox D</label></span></div>
 */
 .kintoneplugin-input-checkbox-item {
   display: block;
@@ -212,17 +212,17 @@
   display: none;
 }
 
-/* ドロップダウンリスト */
+/* Dropdown */
 /*
 <div class="kintoneplugin-dropdown-outer">
   <div class="kintoneplugin-dropdown">
-    <div class="kintoneplugin-dropdown-selected"><span class="kintoneplugin-dropdown-selected-name">ドロップダウン</span></div>
+    <div class="kintoneplugin-dropdown-selected"><span class="kintoneplugin-dropdown-selected-name">Dropdown</span></div>
   </div>
 </div>
 <div class="kintoneplugin-dropdown-list">
-  <div class="kintoneplugin-dropdown-list-item kintoneplugin-dropdown-list-item-selected"><span class="kintoneplugin-dropdown-list-item-name">オプションA</span></div>
-  <div class="kintoneplugin-dropdown-list-item"><span class="kintoneplugin-dropdown-list-item-name">オプションB</span></div>
-  <div class="kintoneplugin-dropdown-list-item"><span class="kintoneplugin-dropdown-list-item-name">オプションC</span></div>
+  <div class="kintoneplugin-dropdown-list-item kintoneplugin-dropdown-list-item-selected"><span class="kintoneplugin-dropdown-list-item-name">Option A</span></div>
+  <div class="kintoneplugin-dropdown-list-item"><span class="kintoneplugin-dropdown-list-item-name">Option B</span></div>
+  <div class="kintoneplugin-dropdown-list-item"><span class="kintoneplugin-dropdown-list-item-name">Option C</span></div>
 </div>
 */
 .kintoneplugin-dropdown-outer {
@@ -291,14 +291,14 @@
   color: #3498db;
 }
 
-/* (セレクトボックス) */
+/* Dropdown (Simple) */
 /*
 <div class="kintoneplugin-select-outer">
   <div class="kintoneplugin-select">
     <select>
-      <option>ドロップダウンリストA</option>
-      <option>ドロップダウンリストB</option>
-      <option>ドロップダウンリストC</option>
+      <option>Option A</option>
+      <option>Option B</option>
+      <option>Option C</option>
     </select>
   </div>
 </div>
@@ -366,10 +366,10 @@
   color: #333;
 }
 
-/* ラジオボタン */
-/* IE8では親要素に .lt-ie9 の指定が必要 */
+/* Radio Button */
+/* For IE8, specify .lt-ie9 for the parent. */
 /*
-<div class="kintoneplugin-input-radio"><span class="kintoneplugin-input-radio-item"><input type="radio" name="radio" value="0" id="radio-0" checked=""><label for="radio-0">ラジオボタンA</label></span><span class="kintoneplugin-input-radio-item"><input type="radio" name="radio" value="1" id="radio-1"><label for="radio-1">ラジオボタンB</label></span></div>
+<div class="kintoneplugin-input-radio"><span class="kintoneplugin-input-radio-item"><input type="radio" name="radio" value="0" id="radio-0" checked=""><label for="radio-0">Radio Button A</label></span><span class="kintoneplugin-input-radio-item"><input type="radio" name="radio" value="1" id="radio-1"><label for="radio-1">Radio Button B</label></span></div>
 */
 .kintoneplugin-input-radio-item {
   display: inline-block;
@@ -447,9 +447,9 @@
   display: none;
 }
 
-/* ボタン */
+/* Button */
 /*
-<button class="kintoneplugin-button-normal">通常のボタン</button>
+<button class="kintoneplugin-button-normal"> A button</button>
 */
 .kintoneplugin-button-normal {
   display: inline-block;
@@ -472,9 +472,9 @@
   cursor: pointer;
 }
 
-/* disabledのボタン */
+/* Disabled button */
 /*
-<button class="kintoneplugin-button-disabled">disabledのボタン</button>
+<button class="kintoneplugin-button-disabled">A disabled button</button>
 */
 .kintoneplugin-button-disabled {
   display: inline-block;
@@ -491,9 +491,9 @@
   line-height: 48px;
 }
 
-/* ダイアログのOKボタン */
+/* Dialog OK button */
 /*
-<button class="kintoneplugin-button-dialog-ok">ダイアログのOKボタン</button>
+<button class="kintoneplugin-button-dialog-ok">OK</button>
 */
 .kintoneplugin-button-dialog-ok {
   display: inline-block;
@@ -515,9 +515,9 @@
   cursor: pointer;
 }
 
-/* ダイアログのキャンセルボタン */
+/* Dialog Cancel button */
 /*
-<button class="kintoneplugin-button-dialog-cancel">ダイアログのキャンセルボタン</button>
+<button class="kintoneplugin-button-dialog-cancel">Cancel</button>
 */
 .kintoneplugin-button-dialog-cancel {
   display: inline-block;
@@ -538,4 +538,118 @@
   background-color: #c8d6dd;
   box-shadow: none;
   cursor: pointer;
+}
+
+
+/* Table */
+/*
+<table class="kintoneplugin-table">
+  <thead>
+    <tr>
+      <th class="kintoneplugin-table-th"><span class="title">Title1</span></th>
+      <th class="kintoneplugin-table-th-blankspace"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <div class="kintoneplugin-table-td-control">
+          <div class="kintoneplugin-table-td-control-value">
+            <div class="kintoneplugin-input-outer">
+              <input class="kintoneplugin-input-text" type="text">
+            </div>
+          </div>
+        </div>
+      </td>
+      <td class="kintoneplugin-table-td-operation">
+        <button type="button" class="kintoneplugin-button-add-row-image" title="Add row"></button>
+        <button type="button" class="kintoneplugin-button-remove-row-image" title="Delete this row"></button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+*/
+.kintoneplugin-table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  margin-left: 18px;
+  margin-bottom: 16px;
+}
+
+.kintoneplugin-table-th {
+  border-color: #3498db;
+  height: 40px;
+  color: #fff;
+  box-sizing: border-box;
+  text-align: left;
+  font-weight: 400;
+  font-size: 12px;
+  white-space: nowrap;
+  border-width: 2px;
+  background-color: #3498db;
+}
+
+.kintoneplugin-table-th .title {
+  display: inline-block;
+  padding: 4px 8px;
+  box-sizing: border-box;
+  min-width: 204px;
+}
+
+.kintoneplugin-table-th-blankspace {
+  background-color: transparent;
+}
+
+.kintoneplugin-table td {
+  border-color: #e3e7e8;
+  border-style: solid;
+  border-width: 0 1px 1px 0;
+  vertical-align: top;
+  padding: 4px 0;
+}
+
+.kintoneplugin-table td:first-child {
+    border-left-width: 1px;
+}
+
+.kintoneplugin-table td.kintoneplugin-table-td-operation {
+  border-right: 0;
+  border-bottom: 0;
+}
+
+.kintoneplugin-table-td-control {
+  padding: 0 8px;
+}
+
+.kintoneplugin-table-td-control-value {
+  overflow: hidden;
+  padding: 4px 0;
+  min-height: 21px;
+  color: #333;
+  background-color: transparent;
+}
+
+.kintoneplugin-table-td-operation .kintoneplugin-button-add-row-image, .kintoneplugin-table-td-operation .kintoneplugin-button-remove-row-image {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+}
+
+.kintoneplugin-table-td-operation .kintoneplugin-button-add-row-image {
+  margin-left: 12px;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAABG0lEQVQ4ja2UMWrDUAyG31TIAUIO0cVbCMToHa0nyF4HqbtPkBPkAqEe/KQ4bclkCB06FDqoQ7Cb5j2/l1L/oMFY/pB+SzImoZzc1BZ1lpObpnKDsihLICkBubIohy4AuQKS0qIsk5DFajsBdAQo+0vIdQBJA+hosdpOgqD7h+c7S7yJQbwg3gSBgPz4J1DfuqNrkyHR2vswTPY5Ofip6mzqQDIfVVUTHpaXLVb/giFXxhhj5uvdLJGYhFmUw3y9mxlb1Jn/kj81Ikvy4X1T1FmwMkB+A+QWkFsgOamq9s/ILRC/Bisb1bPR/2ZszoDkBZC/bp6zc6uORtmAbslH281fV4OkSXjUAPLTIMjb1cg98zy6Vd2l7ecoom+t8LKwzLF7UgAAAABJRU5ErkJggg==) center center no-repeat;
+  border: 1px solid transparent;
+}
+.kintoneplugin-table-td-operation .kintoneplugin-button-add-row-image:hover {
+  cursor: pointer;
+}
+.kintoneplugin-table-td-operation .kintoneplugin-button-remove-row-image {
+  margin-left: 4px;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAABPUlEQVQ4ja2UvW6DMBDHUTMkK0vyQJXoxoaUB2nWxEorMcNgD/gOWbIii7GSJx6Bmdegq1lKF6CUAqYSJ/2HE8dP5/tyHIvFcbynlLpxHO9tsZPGGDsCgI+IrwBAOrW+zxg7WiFBEOwAwEPE6xAyVpqmNwDwgiDYTYIIIU+c8/MSZCzO+XkSyDl//g9oIO8XKEmSk+1pc0LEa5Ikpx4GAP5csFIqVEqFFqjfw8ZdGyrLsjDLMhvs0hX+sBS4EkYIIQeHUuqOP5Rl+WGMqYwxVV3Xn03TfHW+MaYqiuIx/odS6k5mJqV811pHWusoz3OW5znrfK11JKV8m8xs05rZurkS9tPNpTkTQtyFEPfVc9Zm522yAd2Sb7abw6vRXoVZSJqmN0R8mQWNdxUm7hkAXADA/1OjtdZd2n6OFuwblG9sdxWO0ggAAAAASUVORK5CYII=) center center no-repeat;
+  border: 1px solid transparent;
+}
+
+.kintoneplugin-table-td-operation .kintoneplugin-button-remove-row-image:hover {
+  cursor: pointer;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAACi0lEQVQ4jZ2UT0hUQRzHp0uHDtFVk0QqTGtdddXVN/Pe7ubuuu3Me7sY2s1jRZcOQX+kQC+dkrr15xAIElhIEBSZloKHPHTMIlHS9r2ZNdvUNK1Evh3S1WVdNX/wuf1+H+bHzHcIyVET4ZoiJViLjLKrjmBtUtBrdpSetwVzE0L25JrLKBlkh6RgHZJTWwmGLDidk5x2qYhWvaXIidKQ5Gx0U8kGkoJBCfpTcXZpU5HNNS45+7WdaKNwJmZgJORtz1wtqhVKQSd3Klpj2tSRMg28NtzhdZlgHf8rUoJBCoZZy8B4Q+27+578fWQiXFMkOfu6W5kSFL8bA3hQUWwRJVhLdqMOZW7Daq/NKVaa6tFdV9ZJJKetGRLLgBOogENL4bAc0FI4QQ+UZUByipSpIylYP3EEa0vLIrWQfjcWeh5hOTGBP2OfshkfxfLkZ8zduw1HOwZlGZgSOuZjvgGiOL2Rlp2qg6yvxNzdDiwNvsJi3/Ns+l9gaaAX329eh2OcgDR1TJs6Zi3jDVFcuyA3rhnzwa4tRsKVj4S7IJuyAiRcB+Hox6HifticYrHRj7eBqh6SiHjLFGcLGRdgGVAxP1TMlwP/vx7BYEcpcCaEO+6j59Zi1L2bp5HgFPNxH2Ysw24tKcwjhBDyJaJVJ9OZ2xkOp1CCAc1BdFaXXMyI1CTXrkybOr6ZOuQOTpRcFY2E6540EbI3K+zvQ972pGBIWQaSpg6bU0i+/todTmFzioW4D2iux8eG2p6n5eUHcn5Dw4Gq6FhEG0qZOlZOBzAb8yG5GuqlRj/QHMSU0Me7akoub/mfpYXeI/uHfJXmM8318EPY2/sj7h+ctfS+4ZOex7dch8++9JTkbTb3FyHXv8RgEtykAAAAAElFTkSuQmCC) center center no-repeat;
 }

--- a/examples/conditionformat2/css/config.css
+++ b/examples/conditionformat2/css/config.css
@@ -58,7 +58,6 @@
     color: #676767;
     padding-bottom: 2px;
     border-bottom: 3px solid #000000;
-    -ms-display:none;
 }
 
 .cf-plugin-column9{

--- a/examples/conditionformat2/css/config.css
+++ b/examples/conditionformat2/css/config.css
@@ -1,37 +1,66 @@
-.conditionformat-cvalue, .conditionformat-cvalue-date,
-.conditionformat-color, .conditionformat-backgroundcolor, .conditionformat-clear-buttons {
-    margin-right: 10px;
-    margin-bottom: 8px;
+.conditionformat-plugin-block {
+    margin: 10px 0px 10px 0px;
+    border: solid 1px #eee;
+    padding: 20px;
 }
 
-.conditionformat-color, .conditionformat-backgroundcolor {
-    width: 90px;
+#conditionformat-plugin-text-tbody tr:first-child,
+#conditionformat-plugin-date-tbody tr:first-child {
+    display: none;
 }
 
-.conditionformat-size {
-    padding-right: 0px;
-    width: 120px;
+#conditionformat-plugin-date-tbody .conditionformat-plugin-column3 {
+    width: 50px
+}
+
+.kintoneplugin-table-th .title {
+    min-width: 40px;
 }
 
 .conditionformat-ctype {
-    padding-right: 0px;
     width: 150px;
 }
-.conditionformat-cvalue {
-    width: 230px;
+
+.conditionformat-date-type {
+    width: 50px;
 }
 
 .conditionformat-cvalue-date {
-    padding-right: 0px;
     width: 60px;
 }
 
-.conditionformat-today {
+.conditionformat-font {
     width: 120px;
-    color: #327fcb;
 }
 
-.conditionformat-day {
-    width: 50px;
-    color: #327fcb;
+.conditionformat-plugin-column3-select1{
+    display: inline-block;
+    overflow: hidden;
+}
+
+.conditionformat-plugin-date-column3-td {
+    min-width: 260px;
+}
+
+.conditionformat-plugin-column5-td, .conditionformat-plugin-column6-td {
+    min-width: 128px;
+}
+
+.conditionformat-plugin-column5, .conditionformat-plugin-column6 {
+    width: 90px;
+}
+
+.conditionformat-plugin-column5-color, .conditionformat-plugin-column6-color{
+    display:none;
+}
+
+.color-paint-brush {
+    color: #676767;
+    padding-bottom: 2px;
+    border-bottom: 3px solid #000000;
+    -ms-display:none;
+}
+
+.conditionformat-plugin-column9{
+    min-width: 70px;
 }

--- a/examples/conditionformat2/css/config.css
+++ b/examples/conditionformat2/css/config.css
@@ -1,15 +1,15 @@
-.conditionformat-plugin-block {
+.cf-plugin-block {
     margin: 10px 0px 10px 0px;
     border: solid 1px #eee;
     padding: 20px;
 }
 
-#conditionformat-plugin-text-tbody tr:first-child,
-#conditionformat-plugin-date-tbody tr:first-child {
+#cf-plugin-text-tbody tr:first-child,
+#cf-plugin-date-tbody tr:first-child {
     display: none;
 }
 
-#conditionformat-plugin-date-tbody .conditionformat-plugin-column3 {
+#cf-plugin-date-tbody .cf-plugin-column3 {
     width: 50px
 }
 
@@ -17,40 +17,40 @@
     min-width: 40px;
 }
 
-.conditionformat-ctype {
+.cf-ctype {
     width: 150px;
 }
 
-.conditionformat-date-type {
+.cf-date-type {
     width: 50px;
 }
 
-.conditionformat-cvalue-date {
+.cf-cvalue-date {
     width: 60px;
 }
 
-.conditionformat-font {
+.cf-font {
     width: 120px;
 }
 
-.conditionformat-plugin-column3-select1{
+.cf-plugin-column3-select1{
     display: inline-block;
     overflow: hidden;
 }
 
-.conditionformat-plugin-date-column3-td {
+.cf-plugin-date-column3-td {
     min-width: 260px;
 }
 
-.conditionformat-plugin-column5-td, .conditionformat-plugin-column6-td {
+.cf-plugin-column5-td, .cf-plugin-column6-td {
     min-width: 128px;
 }
 
-.conditionformat-plugin-column5, .conditionformat-plugin-column6 {
+.cf-plugin-column5, .cf-plugin-column6 {
     width: 90px;
 }
 
-.conditionformat-plugin-column5-color, .conditionformat-plugin-column6-color{
+.cf-plugin-column5-color, .cf-plugin-column6-color{
     display:none;
 }
 
@@ -61,6 +61,6 @@
     -ms-display:none;
 }
 
-.conditionformat-plugin-column9{
+.cf-plugin-column9{
     min-width: 70px;
 }

--- a/examples/conditionformat2/html/config.html
+++ b/examples/conditionformat2/html/config.html
@@ -1,50 +1,50 @@
-<div id="conditionformat-plugin">
-    <div class="block conditionformat-plugin-block">
-        <div class="kintoneplugin-label">{{html:terms.conditionformat_text_title}}</div>
+<div id="cf-plugin">
+    <div class="block cf-plugin-block">
+        <div class="kintoneplugin-label">{{html:terms.cf_text_title}}</div>
         <div class="kintoneplugin-row">
-            <table class="conditionformat-plugin-text-table kintoneplugin-table">
+            <table class="cf-plugin-text-table kintoneplugin-table">
                 <thead>
                     <tr>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_text_column1}}<span class="kintoneplugin-require">*</span></a></span>
+                            <span class="title">{{html:terms.cf_text_column1}}<span class="kintoneplugin-require">*</span></a></span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_text_column2}}
+                            <span class="title">{{html:terms.cf_text_column2}}
                                 <span class="kintoneplugin-require">*</span>
                             </span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_text_column3}}</span>
+                            <span class="title">{{html:terms.cf_text_column3}}</span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_text_column4}}<span class="kintoneplugin-require">*</span></a></span>
+                            <span class="title">{{html:terms.cf_text_column4}}<span class="kintoneplugin-require">*</span></a></span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_text_column5}}</span>
+                            <span class="title">{{html:terms.cf_text_column5}}</span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_text_column6}}</span>
+                            <span class="title">{{html:terms.cf_text_column6}}</span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_text_column7}}</span>
+                            <span class="title">{{html:terms.cf_text_column7}}</span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_text_column8}}</span>
+                            <span class="title">{{html:terms.cf_text_column8}}</span>
                         </th>
                         <th class="kintoneplugin-table-th-blankspace"></th>
                         <th class="kintoneplugin-table-th-blankspace"></th>
                     </tr>
                 </thead>
-                <tbody id="conditionformat-plugin-text-tbody">
-                    <tr class="conditionformat-plugin-text-line">
+                <tbody id="cf-plugin-text-tbody">
+                    <tr class="cf-plugin-text-line">
                         <td>
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div class="kintoneplugin-select-outer">
                                         <div class="kintoneplugin-select">
-                                            <select class="conditionformat-plugin-column1">
+                                            <select class="cf-plugin-column1">
                                                 <option value="">-----</option>
-                                                <option value="status_process_management">{{html:terms.conditionformat_text_column1_option1}}</option>
+                                                <option value="status_process_management">{{html:terms.cf_text_column1_option1}}</option>
                                             </select>
                                         </div>
                                     </div>
@@ -55,17 +55,17 @@
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div class="kintoneplugin-select-outer">
-                                        <div class="kintoneplugin-select conditionformat-ctype">
-                                            <select class="conditionformat-plugin-column2">
+                                        <div class="kintoneplugin-select cf-ctype">
+                                            <select class="cf-plugin-column2">
                                                 <option value="">-----</option>
-                                                <option value="match">{{html:terms.conditionformat_text_column2_option1}}</option>
-                                                <option value="unmatch">{{html:terms.conditionformat_text_column2_option2}}</option>
-                                                <option value="==">{{html:terms.conditionformat_text_column2_option3}}</option>
-                                                <option value="!=">{{html:terms.conditionformat_text_column2_option4}}</option>
-                                                <option value="<=">{{html:terms.conditionformat_text_column2_option5}}</option>
-                                                <option value="<">{{html:terms.conditionformat_text_column2_option6}}</option>
-                                                <option value=">=">{{html:terms.conditionformat_text_column2_option7}}</option>
-                                                <option value=">">{{html:terms.conditionformat_text_column2_option8}}</option>
+                                                <option value="match">{{html:terms.cf_text_column2_option1}}</option>
+                                                <option value="unmatch">{{html:terms.cf_text_column2_option2}}</option>
+                                                <option value="==">{{html:terms.cf_text_column2_option3}}</option>
+                                                <option value="!=">{{html:terms.cf_text_column2_option4}}</option>
+                                                <option value="<=">{{html:terms.cf_text_column2_option5}}</option>
+                                                <option value="<">{{html:terms.cf_text_column2_option6}}</option>
+                                                <option value=">=">{{html:terms.cf_text_column2_option7}}</option>
+                                                <option value=">">{{html:terms.cf_text_column2_option8}}</option>
                                             </select>
                                         </div>
                                     </div>
@@ -76,7 +76,7 @@
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <span>
-                                        <input class="kintoneplugin-input-text conditionformat-plugin-column3"/>
+                                        <input class="kintoneplugin-input-text cf-plugin-column3"/>
                                     </span>
                                 </div>
                             </div>
@@ -86,33 +86,33 @@
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div class="kintoneplugin-select-outer">
                                         <div class="kintoneplugin-select">
-                                            <select class="conditionformat-plugin-column4">
+                                            <select class="cf-plugin-column4">
                                                 <option value="">-----</option>
-                                                <option value="status_process_management">{{html:terms.conditionformat_text_column4_option1}}</option>
+                                                <option value="status_process_management">{{html:terms.cf_text_column4_option1}}</option>
                                             </select>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </td>
-                        <td class="conditionformat-plugin-column5-td">
+                        <td class="cf-plugin-column5-td">
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div>
-                                        <input type="text" class="kintoneplugin-input-text conditionformat-plugin-column5" maxlength="7" value="#000000"/>
+                                        <input type="text" class="kintoneplugin-input-text cf-plugin-column5" maxlength="7" value="#000000"/>
                                         <i class="fa fa-paint-brush color-paint-brush"></i>
-                                        <input type="color" class="conditionformat-plugin-column5-color"/>
+                                        <input type="color" class="cf-plugin-column5-color"/>
                                     </div>
                                 </div>
                             </div>
                         </td>
-                        <td class="conditionformat-plugin-column6-td">
+                        <td class="cf-plugin-column6-td">
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div>
-                                        <input type="text" class="kintoneplugin-input-text conditionformat-plugin-column6" maxlength="7" value="#">
+                                        <input type="text" class="kintoneplugin-input-text cf-plugin-column6" maxlength="7" value="#">
                                         <i class="fa fa-paint-brush color-paint-brush"></i>
-                                        <input type="color" class="conditionformat-plugin-column6-color"/>
+                                        <input type="color" class="cf-plugin-column6-color"/>
                                     </div>
                                 </div>
                             </div>
@@ -121,13 +121,13 @@
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div class="kintoneplugin-select-outer">
-                                        <div class="kintoneplugin-select conditionformat-font">
-                                            <select class="conditionformat-plugin-column7">
-                                                <option value="">{{html:terms.conditionformat_text_column7_option1}}</option>
-                                                <option value="x-small">{{html:terms.conditionformat_text_column7_option2}}</option>
-                                                <option value="small">{{html:terms.conditionformat_text_column7_option3}}</option>
-                                                <option value="large">{{html:terms.conditionformat_text_column7_option4}}</option>
-                                                <option value="x-large">{{html:terms.conditionformat_text_column7_option5}}</option>
+                                        <div class="kintoneplugin-select cf-font">
+                                            <select class="cf-plugin-column7">
+                                                <option value="">{{html:terms.cf_text_column7_option1}}</option>
+                                                <option value="x-small">{{html:terms.cf_text_column7_option2}}</option>
+                                                <option value="small">{{html:terms.cf_text_column7_option3}}</option>
+                                                <option value="large">{{html:terms.cf_text_column7_option4}}</option>
+                                                <option value="x-large">{{html:terms.cf_text_column7_option5}}</option>
                                             </select>
                                         </div>
                                     </div>
@@ -138,19 +138,19 @@
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div class="kintoneplugin-select-outer">
-                                        <div class="kintoneplugin-select conditionformat-font">
-                                            <select class="conditionformat-plugin-column8">
-                                                <option value="">{{html:terms.conditionformat_text_column8_option1}}</option>
-                                                <option value="bold">{{html:terms.conditionformat_text_column8_option2}}</option>
-                                                <option value="underline">{{html:terms.conditionformat_text_column8_option3}}</option>
-                                                <option value="line-through">{{html:terms.conditionformat_text_column8_option4}}</option>
+                                        <div class="kintoneplugin-select cf-font">
+                                            <select class="cf-plugin-column8">
+                                                <option value="">{{html:terms.cf_text_column8_option1}}</option>
+                                                <option value="bold">{{html:terms.cf_text_column8_option2}}</option>
+                                                <option value="underline">{{html:terms.cf_text_column8_option3}}</option>
+                                                <option value="line-through">{{html:terms.cf_text_column8_option4}}</option>
                                             </select>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </td>
-                        <td class="kintoneplugin-table-td-operation conditionformat-plugin-column9">
+                        <td class="kintoneplugin-table-td-operation cf-plugin-column9">
                             <button type="button" class="kintoneplugin-button-add-row-image addList" title="Add row"></button>
                             <button type="button" class="kintoneplugin-button-remove-row-image removeList" title="Delete this row"></button>
                         </td>
@@ -159,48 +159,48 @@
             </table>
         </div>
     </div>
-    <div class="block conditionformat-plugin-block">
-        <div class="kintoneplugin-label">{{html:terms.conditionformat_date_title}}</div>
+    <div class="block cf-plugin-block">
+        <div class="kintoneplugin-label">{{html:terms.cf_date_title}}</div>
         <div class="kintoneplugin-row">
-            <table class="conditionformat-plugin-date-table kintoneplugin-table">
+            <table class="cf-plugin-date-table kintoneplugin-table">
                 <thead>
                     <tr>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_date_column1}}<span class="kintoneplugin-require">*</span></span>
+                            <span class="title">{{html:terms.cf_date_column1}}<span class="kintoneplugin-require">*</span></span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_date_column2}}<span class="kintoneplugin-require">*</span></span>
+                            <span class="title">{{html:terms.cf_date_column2}}<span class="kintoneplugin-require">*</span></span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_date_column3}}</span>
+                            <span class="title">{{html:terms.cf_date_column3}}</span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_date_column4}}<span class="kintoneplugin-require">*</span></span>
+                            <span class="title">{{html:terms.cf_date_column4}}<span class="kintoneplugin-require">*</span></span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_date_column5}}</span>
+                            <span class="title">{{html:terms.cf_date_column5}}</span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_date_column6}}</span>
+                            <span class="title">{{html:terms.cf_date_column6}}</span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_date_column7}}</span>
+                            <span class="title">{{html:terms.cf_date_column7}}</span>
                         </th>
                         <th class="kintoneplugin-table-th">
-                            <span class="title">{{html:terms.conditionformat_date_column8}}</span>
+                            <span class="title">{{html:terms.cf_date_column8}}</span>
                         </th>
                         <th class="kintoneplugin-table-th-blankspace"></th>
                         <th class="kintoneplugin-table-th-blankspace"></th>
                     </tr>
                 </thead>
-                <tbody id="conditionformat-plugin-date-tbody">
-                    <tr class="conditionformat-plugin-date-line">
+                <tbody id="cf-plugin-date-tbody">
+                    <tr class="cf-plugin-date-line">
                         <td>
                             <div class="kintoneplugin-table-td-control">
                               <div class="kintoneplugin-table-td-control-value">
                                 <div class="kintoneplugin-select-outer">
                                     <div class="kintoneplugin-select">
-                                        <select class="conditionformat-plugin-column1">
+                                        <select class="cf-plugin-column1">
                                             <option value="">-----</option>
                                         </select>
                                     </div>
@@ -212,33 +212,33 @@
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div class="kintoneplugin-select-outer">
-                                        <div class="kintoneplugin-select conditionformat-ctype">
-                                            <select class="conditionformat-plugin-column2">
+                                        <div class="kintoneplugin-select cf-ctype">
+                                            <select class="cf-plugin-column2">
                                                 <option value="">-----</option>
-                                                <option value="==">{{html:terms.conditionformat_date_column2_option1}}</option>
-                                                <option value="!=">{{html:terms.conditionformat_date_column2_option2}}</option>
-                                                <option value="<=">{{html:terms.conditionformat_date_column2_option3}}</option>
-                                                <option value="<">{{html:terms.conditionformat_date_column2_option4}}</option>
-                                                <option value=">=">{{html:terms.conditionformat_date_column2_option5}}</option>
-                                                <option value=">">{{html:terms.conditionformat_date_column2_option6}}</option>
+                                                <option value="==">{{html:terms.cf_date_column2_option1}}</option>
+                                                <option value="!=">{{html:terms.cf_date_column2_option2}}</option>
+                                                <option value="<=">{{html:terms.cf_date_column2_option3}}</option>
+                                                <option value="<">{{html:terms.cf_date_column2_option4}}</option>
+                                                <option value=">=">{{html:terms.cf_date_column2_option5}}</option>
+                                                <option value=">">{{html:terms.cf_date_column2_option6}}</option>
                                             </select>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </td>
-                        <td class="conditionformat-plugin-date-column3-td">
+                        <td class="cf-plugin-date-column3-td">
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
-                                    <span class="conditionformat-plugin-column3-select1">
-                                        {{html:terms.conditionformat_date_column2_desc1}}
-                                        <input class="kintoneplugin-input-text conditionformat-plugin-column3" value="0"/>
-                                        {{html:terms.conditionformat_date_column2_desc2}}
+                                    <span class="cf-plugin-column3-select1">
+                                        {{html:terms.cf_date_column2_desc1}}
+                                        <input class="kintoneplugin-input-text cf-plugin-column3" value="0"/>
+                                        {{html:terms.cf_date_column2_desc2}}
                                     </span>
-                                    <span class="kintoneplugin-select conditionformat-date-type">
-                                        <select class="conditionformat-plugin-column3-select2">
-                                            <option value="before">{{html:terms.conditionformat_date_column3_option1}}</option>
-                                            <option value="after">{{html:terms.conditionformat_date_column3_option2}}</option>
+                                    <span class="kintoneplugin-select cf-date-type">
+                                        <select class="cf-plugin-column3-select2">
+                                            <option value="before">{{html:terms.cf_date_column3_option1}}</option>
+                                            <option value="after">{{html:terms.cf_date_column3_option2}}</option>
                                         </select>
                                     </span>
                                 </div>
@@ -249,33 +249,33 @@
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div class="kintoneplugin-select-outer">
                                         <div class="kintoneplugin-select">
-                                            <select class="conditionformat-plugin-column4">
+                                            <select class="cf-plugin-column4">
                                                 <option value="">-----</option>
-                                                <option value="status_process_management">{{html:terms.conditionformat_date_column4_option1}}</option>
+                                                <option value="status_process_management">{{html:terms.cf_date_column4_option1}}</option>
                                             </select>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </td>
-                        <td class="conditionformat-plugin-column5-td">
+                        <td class="cf-plugin-column5-td">
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div>
-                                        <input type="text" class="kintoneplugin-input-text conditionformat-plugin-column5" maxlength="7" value="#000000"/>
+                                        <input type="text" class="kintoneplugin-input-text cf-plugin-column5" maxlength="7" value="#000000"/>
                                         <i class="fa fa-paint-brush color-paint-brush"></i>
-                                        <input type="color" class="conditionformat-plugin-column5-color"/>
+                                        <input type="color" class="cf-plugin-column5-color"/>
                                     </div>
                                 </div>
                             </div>
                         </td>
-                        <td class="conditionformat-plugin-column6-td">
+                        <td class="cf-plugin-column6-td">
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div>
-                                    	<input type="text" class="kintoneplugin-input-text conditionformat-plugin-column6" maxlength="7" value="#"/>
+                                    	<input type="text" class="kintoneplugin-input-text cf-plugin-column6" maxlength="7" value="#"/>
                                         <i class="fa fa-paint-brush color-paint-brush"></i>
-                                        <input type="color" class="conditionformat-plugin-column6-color"/>
+                                        <input type="color" class="cf-plugin-column6-color"/>
                                     </div>
                                 </div>
                             </div>
@@ -284,13 +284,13 @@
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                         <div class="kintoneplugin-select-outer">
-                                        <div class="kintoneplugin-select conditionformat-font">
-                                            <select class="conditionformat-plugin-column7">
-                                                <option value="">{{html:terms.conditionformat_date_column7_option1}}</option>
-                                                <option value="x-small">{{html:terms.conditionformat_date_column7_option2}}</option>
-                                                <option value="small">{{html:terms.conditionformat_date_column7_option3}}</option>
-                                                <option value="large">{{html:terms.conditionformat_date_column7_option4}}</option>
-                                                <option value="x-large">{{html:terms.conditionformat_date_column7_option5}}</option>
+                                        <div class="kintoneplugin-select cf-font">
+                                            <select class="cf-plugin-column7">
+                                                <option value="">{{html:terms.cf_date_column7_option1}}</option>
+                                                <option value="x-small">{{html:terms.cf_date_column7_option2}}</option>
+                                                <option value="small">{{html:terms.cf_date_column7_option3}}</option>
+                                                <option value="large">{{html:terms.cf_date_column7_option4}}</option>
+                                                <option value="x-large">{{html:terms.cf_date_column7_option5}}</option>
                                             </select>
                                         </div>
                                     </div>
@@ -301,19 +301,19 @@
                             <div class="kintoneplugin-table-td-control">
                                 <div class="kintoneplugin-table-td-control-value">
                                     <div class="kintoneplugin-select-outer">
-                                        <div class="kintoneplugin-select conditionformat-font">
-                                            <select class="conditionformat-plugin-column8">
-                                                <option value="">{{html:terms.conditionformat_date_column8_option1}}</option>
-                                                <option value="bold">{{html:terms.conditionformat_date_column8_option2}}</option>
-                                                <option value="underline">{{html:terms.conditionformat_date_column8_option3}}</option>
-                                                <option value="line-through">{{html:terms.conditionformat_date_column8_option4}}</option>
+                                        <div class="kintoneplugin-select cf-font">
+                                            <select class="cf-plugin-column8">
+                                                <option value="">{{html:terms.cf_date_column8_option1}}</option>
+                                                <option value="bold">{{html:terms.cf_date_column8_option2}}</option>
+                                                <option value="underline">{{html:terms.cf_date_column8_option3}}</option>
+                                                <option value="line-through">{{html:terms.cf_date_column8_option4}}</option>
                                             </select>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </td>
-                        <td class="kintoneplugin-table-td-operation conditionformat-plugin-column9">
+                        <td class="kintoneplugin-table-td-operation cf-plugin-column9">
                             <button type="button" class="kintoneplugin-button-add-row-image addList" title="Add row"></button>
                             <button type="button" class="kintoneplugin-button-remove-row-image removeList" title="Delete this row"></button>
                         </td>
@@ -323,7 +323,7 @@
         </div>
     </div>
     <div class="block">
-        <button class="kintoneplugin-button-dialog-ok" id="conditionformat-submit" type="button">{{html:terms.plugin_submit}}</button>
-        <button class="kintoneplugin-button-dialog-cancel" id="conditionformat-cancel" type="button">{{html:terms.plugin_cancel}}</button>
+        <button class="kintoneplugin-button-dialog-ok" id="cf-submit" type="button">{{html:terms.cf_plugin_submit}}</button>
+        <button class="kintoneplugin-button-dialog-cancel" id="cf-cancel" type="button">{{html:terms.cf_plugin_cancel}}</button>
     </div>
 </div>

--- a/examples/conditionformat2/html/config.html
+++ b/examples/conditionformat2/html/config.html
@@ -1,1622 +1,329 @@
-<div class>
-	<div class="block">
-		<div class="kintoneplugin-label">
-			文字条件書式
-		</div>
-		<div class="kintoneplugin-row">
-			<table class="conditionformat-plugin-text-table">
-				<tr class = "conditionformat-plugin-text-line-name">
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="複数条件を満たす場合は No. の大きいものが優先されます。">No.</a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="条件を比較するフィールドを選択してください。">書式条件フィールド
-								<span class="kintoneplugin-require">*</span></a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="比較条件式を選択してください。">条件式
-								<span class="kintoneplugin-require">*</span></a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="書式条件フィールドの値と比較する値を入力してください。
-								どちらも半角数字の場合、数値データとして条件比較を行います。">条件値
-								</a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="条件が合致していた場合、書式を変更するフィールドを選択してください。">書式変更フィールド
-								<span class="kintoneplugin-require">*</span></a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="書式変更フィールドに設定する文字色を「#000000」～「#FFFFFF」で入力してください。設定例）
-								赤：#FF0000 緑：#00FF00
-								青：#0000FF 黄：#FFFF00">文字色</a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="書式変更フィールドに設定する背景色を「#000000」～「#FFFFFF」で入力してください。
-								変更しない場合は#のみを入力してください。設定例）
-								赤：#FF0000 緑：#00FF00
-								青：#0000FF 黄：#FFFF00">背景色</a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="書式変更フィールドに設定する文字のサイズを入力してください">サイズ</a>
-							</div>
-						</span>
-					</td>
-				</tr>
-			<!-- 1行目-->
-				<tr class = "conditionformat-plugin-text-line-1">
-					<td>
-						<span>1</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_1" id="conditionformat-cfield_text_1">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_1" id="conditionformat-ctype_text_1">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_1"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_1" id="conditionformat-tfield_text_1">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_1"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_1"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_1" id="conditionformat-tsize_text_1">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 2行目-->
-				<tr class = "conditionformat-plugin-text-line-2">
-					<td>
-						<span>2</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_2" id="conditionformat-cfield_text_2">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_2" id="conditionformat-ctype_text_2">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_2"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_2" id="conditionformat-tfield_text_2">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_2"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_2"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_2" id="conditionformat-tsize_text_2">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 3行目-->
-				<tr class = "conditionformat-plugin-text-line-3">
-					<td>
-						<span>3</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_3" id="conditionformat-cfield_text_3">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_3" id="conditionformat-ctype_text_3">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_3"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_3" id="conditionformat-tfield_text_3">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_3"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_3"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_3" id="conditionformat-tsize_text_3">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 4行目-->
-				<tr class = "conditionformat-plugin-text-line-4">
-					<td>
-						<span>4</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_4" id="conditionformat-cfield_text_4">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_4" id="conditionformat-ctype_text_4">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_4"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_4" id="conditionformat-tfield_text_4">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_4"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_4"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_4" id="conditionformat-tsize_text_4">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 5行目-->
-				<tr class = "conditionformat-plugin-text-line-5">
-					<td>
-						<span>5</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_5" id="conditionformat-cfield_text_5">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_5" id="conditionformat-ctype_text_5">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_5"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_5" id="conditionformat-tfield_text_5">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_5"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_5"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_5" id="conditionformat-tsize_text_5">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 6行目-->
-				<tr class = "conditionformat-plugin-text-line-6">
-					<td>
-						<span>6</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_6" id="conditionformat-cfield_text_6">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_6" id="conditionformat-ctype_text_6">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_6"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_6" id="conditionformat-tfield_text_6">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_6"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_6"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_6" id="conditionformat-tsize_text_6">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 7行目-->
-				<tr class = "conditionformat-plugin-text-line-7">
-					<td>
-						<span>7</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_7" id="conditionformat-cfield_text_7">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_7" id="conditionformat-ctype_text_7">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_7"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_7" id="conditionformat-tfield_text_7">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_7"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_7"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_7" id="conditionformat-tsize_text_7">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 8行目-->
-				<tr class = "conditionformat-plugin-text-line-8">
-					<td>
-						<span>8</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_8" id="conditionformat-cfield_text_8">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_8" id="conditionformat-ctype_text_8">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_8"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_8" id="conditionformat-tfield_text_8">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_8"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_8"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_8" id="conditionformat-tsize_text_8">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 9行目-->
-				<tr class = "conditionformat-plugin-text-line-9">
-					<td>
-						<span>9</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_9" id="conditionformat-cfield_text_9">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_9" id="conditionformat-ctype_text_9">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_9"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_9" id="conditionformat-tfield_text_9">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_9"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_9"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_9" id="conditionformat-tsize_text_9">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 10行目-->
-				<tr class = "conditionformat-plugin-text-line-10">
-					<td>
-						<span>10</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_text_10" id="conditionformat-cfield_text_10">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_text_10" id="conditionformat-ctype_text_10">
-									<option value="">-----</option>
-									<option value="match">条件値を含む</option>
-									<option value="unmatch">条件値を含まない</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以下)</option>
-									<option value="<"><(より小さい)</option>
-									<option value=">=">≧(以上)</option>
-									<option value=">">>(より大きい)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue" id="conditionformat-cvalue_text_10"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_text_10" id="conditionformat-tfield_text_10">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_text_10"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_text_10"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_text_10" id="conditionformat-tsize_text_10">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
-	<div class="block">
-		<div class="kintoneplugin-label">
-			日付条件書式
-		</div>
-		<div class="kintoneplugin-row">
-			<table class="conditionformat-plugin-date-table" id="conditionformat-plugin-date-table-code">
-				<tr class = "conditionformat-plugin-text-line-name">
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="複数条件を満たす場合は No. の大きいものが優先されます。">No.</a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="条件を比較するフィールドを選択してください。">書式条件フィールド</a>
-								<span class="kintoneplugin-require">*</span>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="比較条件式を選択してください。">条件式</a>
-								<span class="kintoneplugin-require">*</span>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="「条件値＝(今日の日付)＋(入力日数)」で算出されます。
-										半角数字を入力してください。
-										「○日前」を入力する場合は - (マイナス) を、
-										「今日の日付」に設定したい場合は 0 (ゼロ) を入力してください。">条件値
-										<span class="kintoneplugin-require">*</span>
-								</a>
-							</div>
-						</span>
-					</td>
-					<td>
-					</td>
-					<td>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="条件が合致していた場合、書式を変更するフィールドを選択してください。">書式変更フィールド</a>
-								<span class="kintoneplugin-require">*</span>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="書式変更フィールドに設定する文字色を「#000000」～「#FFFFFF」で入力してください
-								設定例）
-								赤：#FF0000 緑：#00FF00
-								青：#0000FF 黄：#FFFF00">文字色</a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="書式変更フィールドに設定する背景色を「#000000」～「#FFFFFF」で入力してください
-								設定例）
-								赤：#FF0000 緑：#00FF00
-								青：#0000FF 黄：#FFFF00">背景色</a>
-							</div>
-						</span>
-					</td>
-					<td>
-						<span>
-							<div class="conditionformat-plugin-tooltip">
-								<a title="書式変更フィールドに設定する文字のサイズを入力してください">サイズ</a>
-							</div>
-						</span>
-					</td>
-				</tr>
-			<!-- 1行目 -->
-				<tr class="conditionformat-plugin-date-line-1" id="conditionformat-plugin-date-line-code-1">
-					<td>
-						<span>1</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_1" id="conditionformat-cfield_date_1">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_1" id="conditionformat-ctype_date_1">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_1" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_1" id="conditionformat-tfield_date_1">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_1"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_1"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_1" id="conditionformat-tsize_date_1">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 2行目 -->
-				<tr class="conditionformat-plugin-date-line-2" id="conditionformat-plugin-date-line-code-2">
-					<td>
-						<span>2</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_2" id="conditionformat-cfield_date_2">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_2" id="conditionformat-ctype_date_2">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_2" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_2" id="conditionformat-tfield_date_2">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_2"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_2"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_2" id="conditionformat-tsize_date_2">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 3行目 -->
-				<tr class="conditionformat-plugin-date-line-3" id="conditionformat-plugin-date-line-code-3">
-					<td>
-						<span>3</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_3" id="conditionformat-cfield_date_3">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_3" id="conditionformat-ctype_date_3">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_3" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_3" id="conditionformat-tfield_date_3">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_3"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_3"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_3" id="conditionformat-tsize_date_3">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 4行目 -->
-				<tr class="conditionformat-plugin-date-line-4" id="conditionformat-plugin-date-line-code-4">
-					<td>
-						<span>4</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_4" id="conditionformat-cfield_date_4">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_4" id="conditionformat-ctype_date_4">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_4" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_4" id="conditionformat-tfield_date_4">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_4"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_4"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_4" id="conditionformat-tsize_date_4">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 5行目 -->
-				<tr class="conditionformat-plugin-date-line-5" id="conditionformat-plugin-date-line-code-5">
-					<td>
-						<span>5</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_5" id="conditionformat-cfield_date_5">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_5" id="conditionformat-ctype_date_5">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_5" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_5" id="conditionformat-tfield_date_5">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_5"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_5"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_5" id="conditionformat-tsize_date_5">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-				<!-- ボタン -->
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 6行目 -->
-				<tr class="conditionformat-plugin-date-line-6" id="conditionformat-plugin-date-line-code-6">
-					<td>
-						<span>6</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_6" id="conditionformat-cfield_date_6">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_6" id="conditionformat-ctype_date_6">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_6" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_6" id="conditionformat-tfield_date_6">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_6"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_6"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_6" id="conditionformat-tsize_date_6">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 7行目 -->
-				<tr class="conditionformat-plugin-date-line-7" id="conditionformat-plugin-date-line-code-7">
-					<td>
-						<span>7</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_7" id="conditionformat-cfield_date_7">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_7" id="conditionformat-ctype_date_7">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_7" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_7" id="conditionformat-tfield_date_7">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_7"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_7"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_7" id="conditionformat-tsize_date_7">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 8行目 -->
-				<tr class="conditionformat-plugin-date-line-8" id="conditionformat-plugin-date-line-code-8">
-					<td>
-						<span>8</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_8" id="conditionformat-cfield_date_8">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_8" id="conditionformat-ctype_date_8">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_8" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_8" id="conditionformat-tfield_date_8">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_8"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_8"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_8" id="conditionformat-tsize_date_8">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 9行目 -->
-				<tr class="conditionformat-plugin-date-line-9" id="conditionformat-plugin-date-line-code-9">
-					<td>
-						<span>9</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_9" id="conditionformat-cfield_date_9">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_9" id="conditionformat-ctype_date_9">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_9" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_9" id="conditionformat-tfield_date_9">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_9"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_9"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_9" id="conditionformat-tsize_date_9">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			<!-- 10行目 -->
-				<tr class="conditionformat-plugin-date-line-10" id="conditionformat-plugin-date-line-code-10">
-					<td>
-						<span>10</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-cfield_date_10" id="conditionformat-cfield_date_10">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-ctype">
-								<select name="conditionformat-ctype_date_10" id="conditionformat-ctype_date_10">
-									<option value="">-----</option>
-									<option value="==">=(等しい)</option>
-									<option value="!=">≠(等しくない)</option>
-									<option value="<=">≦(以前)</option>
-									<option value="<"><(より前)</option>
-									<option value=">=">≧(以後)</option>
-									<option value=">">>(より後)</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td class="conditionformat-today" nowrap>今日の日付から</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-cvalue-date" id="conditionformat-cvalue_date_10" value="0">
-						</span>
-					</td>
-					<td class="conditionformat-day" nowrap>日後</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select">
-								<select name="conditionformat-tfield_date_10" id="conditionformat-tfield_date_10">
-									<option value="">-----</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-color" maxlength="7" value="#000000" id="conditionformat-tcolor_date_10"/>
-						</span>
-					</td>
-					<td>
-						<span>
-							<input class="kintoneplugin-input-text conditionformat-backgroundcolor" maxlength="7" value="#" id="conditionformat-tbgcolor_date_10"/>
-						</span>
-					</td>
-					<td>
-						<div class="kintoneplugin-select-outer">
-							<div class="kintoneplugin-select conditionformat-size">
-								<select name="conditionformat-tsize_date_10" id="conditionformat-tsize_date_10">
-									<option value="">変更なし</option>
-									<option value="x-small">小さい</option>
-									<option value="small">やや小さい</option>
-									<option value="large">やや大きい</option>
-									<option value="x-large">大きい</option>
-								</select>
-							</div>
-						</div>
-					</td>
-					<td>
-					<button class="conditionformat-clear-buttons fa fa-eraser fa-2x" type="button"></button>
-					</td>
-				</tr>
-			</table>
-		</div>
-	</div>
-	<div class="block">
-		<button class="kintoneplugin-button-dialog-ok" id="conditionformat-submit" type="button">保存する</button>
-		<button class="kintoneplugin-button-dialog-cancel" id="conditionformat-cancel" type="button">キャンセル</button>
-	</div>
+<div id="conditionformat-plugin">
+    <div class="block conditionformat-plugin-block">
+        <div class="kintoneplugin-label">{{html:terms.conditionformat_text_title}}</div>
+        <div class="kintoneplugin-row">
+            <table class="conditionformat-plugin-text-table kintoneplugin-table">
+                <thead>
+                    <tr>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_text_column1}}<span class="kintoneplugin-require">*</span></a></span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_text_column2}}
+                                <span class="kintoneplugin-require">*</span>
+                            </span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_text_column3}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_text_column4}}<span class="kintoneplugin-require">*</span></a></span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_text_column5}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_text_column6}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_text_column7}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_text_column8}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th-blankspace"></th>
+                        <th class="kintoneplugin-table-th-blankspace"></th>
+                    </tr>
+                </thead>
+                <tbody id="conditionformat-plugin-text-tbody">
+                    <tr class="conditionformat-plugin-text-line">
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div class="kintoneplugin-select-outer">
+                                        <div class="kintoneplugin-select">
+                                            <select class="conditionformat-plugin-column1">
+                                                <option value="">-----</option>
+                                                <option value="status_process_management">{{html:terms.conditionformat_text_column1_option1}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div class="kintoneplugin-select-outer">
+                                        <div class="kintoneplugin-select conditionformat-ctype">
+                                            <select class="conditionformat-plugin-column2">
+                                                <option value="">-----</option>
+                                                <option value="match">{{html:terms.conditionformat_text_column2_option1}}</option>
+                                                <option value="unmatch">{{html:terms.conditionformat_text_column2_option2}}</option>
+                                                <option value="==">{{html:terms.conditionformat_text_column2_option3}}</option>
+                                                <option value="!=">{{html:terms.conditionformat_text_column2_option4}}</option>
+                                                <option value="<=">{{html:terms.conditionformat_text_column2_option5}}</option>
+                                                <option value="<">{{html:terms.conditionformat_text_column2_option6}}</option>
+                                                <option value=">=">{{html:terms.conditionformat_text_column2_option7}}</option>
+                                                <option value=">">{{html:terms.conditionformat_text_column2_option8}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <span>
+                                        <input class="kintoneplugin-input-text conditionformat-plugin-column3"/>
+                                    </span>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div class="kintoneplugin-select-outer">
+                                        <div class="kintoneplugin-select">
+                                            <select class="conditionformat-plugin-column4">
+                                                <option value="">-----</option>
+                                                <option value="status_process_management">{{html:terms.conditionformat_text_column4_option1}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="conditionformat-plugin-column5-td">
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div>
+                                        <input type="text" class="kintoneplugin-input-text conditionformat-plugin-column5" maxlength="7" value="#000000"/>
+                                        <i class="fa fa-paint-brush color-paint-brush"></i>
+                                        <input type="color" class="conditionformat-plugin-column5-color"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="conditionformat-plugin-column6-td">
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div>
+                                        <input type="text" class="kintoneplugin-input-text conditionformat-plugin-column6" maxlength="7" value="#">
+                                        <i class="fa fa-paint-brush color-paint-brush"></i>
+                                        <input type="color" class="conditionformat-plugin-column6-color"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div class="kintoneplugin-select-outer">
+                                        <div class="kintoneplugin-select conditionformat-font">
+                                            <select class="conditionformat-plugin-column7">
+                                                <option value="">{{html:terms.conditionformat_text_column7_option1}}</option>
+                                                <option value="x-small">{{html:terms.conditionformat_text_column7_option2}}</option>
+                                                <option value="small">{{html:terms.conditionformat_text_column7_option3}}</option>
+                                                <option value="large">{{html:terms.conditionformat_text_column7_option4}}</option>
+                                                <option value="x-large">{{html:terms.conditionformat_text_column7_option5}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div class="kintoneplugin-select-outer">
+                                        <div class="kintoneplugin-select conditionformat-font">
+                                            <select class="conditionformat-plugin-column8">
+                                                <option value="">{{html:terms.conditionformat_text_column8_option1}}</option>
+                                                <option value="bold">{{html:terms.conditionformat_text_column8_option2}}</option>
+                                                <option value="underline">{{html:terms.conditionformat_text_column8_option3}}</option>
+                                                <option value="line-through">{{html:terms.conditionformat_text_column8_option4}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="kintoneplugin-table-td-operation conditionformat-plugin-column9">
+                            <button type="button" class="kintoneplugin-button-add-row-image addList" title="Add row"></button>
+                            <button type="button" class="kintoneplugin-button-remove-row-image removeList" title="Delete this row"></button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="block conditionformat-plugin-block">
+        <div class="kintoneplugin-label">{{html:terms.conditionformat_date_title}}</div>
+        <div class="kintoneplugin-row">
+            <table class="conditionformat-plugin-date-table kintoneplugin-table">
+                <thead>
+                    <tr>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_date_column1}}<span class="kintoneplugin-require">*</span></span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_date_column2}}<span class="kintoneplugin-require">*</span></span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_date_column3}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_date_column4}}<span class="kintoneplugin-require">*</span></span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_date_column5}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_date_column6}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_date_column7}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th">
+                            <span class="title">{{html:terms.conditionformat_date_column8}}</span>
+                        </th>
+                        <th class="kintoneplugin-table-th-blankspace"></th>
+                        <th class="kintoneplugin-table-th-blankspace"></th>
+                    </tr>
+                </thead>
+                <tbody id="conditionformat-plugin-date-tbody">
+                    <tr class="conditionformat-plugin-date-line">
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                              <div class="kintoneplugin-table-td-control-value">
+                                <div class="kintoneplugin-select-outer">
+                                    <div class="kintoneplugin-select">
+                                        <select class="conditionformat-plugin-column1">
+                                            <option value="">-----</option>
+                                        </select>
+                                    </div>
+                                </div>
+                              </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div class="kintoneplugin-select-outer">
+                                        <div class="kintoneplugin-select conditionformat-ctype">
+                                            <select class="conditionformat-plugin-column2">
+                                                <option value="">-----</option>
+                                                <option value="==">{{html:terms.conditionformat_date_column2_option1}}</option>
+                                                <option value="!=">{{html:terms.conditionformat_date_column2_option2}}</option>
+                                                <option value="<=">{{html:terms.conditionformat_date_column2_option3}}</option>
+                                                <option value="<">{{html:terms.conditionformat_date_column2_option4}}</option>
+                                                <option value=">=">{{html:terms.conditionformat_date_column2_option5}}</option>
+                                                <option value=">">{{html:terms.conditionformat_date_column2_option6}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="conditionformat-plugin-date-column3-td">
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <span class="conditionformat-plugin-column3-select1">
+                                        {{html:terms.conditionformat_date_column2_desc1}}
+                                        <input class="kintoneplugin-input-text conditionformat-plugin-column3" value="0"/>
+                                        {{html:terms.conditionformat_date_column2_desc2}}
+                                    </span>
+                                    <span class="kintoneplugin-select conditionformat-date-type">
+                                        <select class="conditionformat-plugin-column3-select2">
+                                            <option value="before">{{html:terms.conditionformat_date_column3_option1}}</option>
+                                            <option value="after">{{html:terms.conditionformat_date_column3_option2}}</option>
+                                        </select>
+                                    </span>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div class="kintoneplugin-select-outer">
+                                        <div class="kintoneplugin-select">
+                                            <select class="conditionformat-plugin-column4">
+                                                <option value="">-----</option>
+                                                <option value="status_process_management">{{html:terms.conditionformat_date_column4_option1}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="conditionformat-plugin-column5-td">
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div>
+                                        <input type="text" class="kintoneplugin-input-text conditionformat-plugin-column5" maxlength="7" value="#000000"/>
+                                        <i class="fa fa-paint-brush color-paint-brush"></i>
+                                        <input type="color" class="conditionformat-plugin-column5-color"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="conditionformat-plugin-column6-td">
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div>
+                                    	<input type="text" class="kintoneplugin-input-text conditionformat-plugin-column6" maxlength="7" value="#"/>
+                                        <i class="fa fa-paint-brush color-paint-brush"></i>
+                                        <input type="color" class="conditionformat-plugin-column6-color"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                        <div class="kintoneplugin-select-outer">
+                                        <div class="kintoneplugin-select conditionformat-font">
+                                            <select class="conditionformat-plugin-column7">
+                                                <option value="">{{html:terms.conditionformat_date_column7_option1}}</option>
+                                                <option value="x-small">{{html:terms.conditionformat_date_column7_option2}}</option>
+                                                <option value="small">{{html:terms.conditionformat_date_column7_option3}}</option>
+                                                <option value="large">{{html:terms.conditionformat_date_column7_option4}}</option>
+                                                <option value="x-large">{{html:terms.conditionformat_date_column7_option5}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="kintoneplugin-table-td-control">
+                                <div class="kintoneplugin-table-td-control-value">
+                                    <div class="kintoneplugin-select-outer">
+                                        <div class="kintoneplugin-select conditionformat-font">
+                                            <select class="conditionformat-plugin-column8">
+                                                <option value="">{{html:terms.conditionformat_date_column8_option1}}</option>
+                                                <option value="bold">{{html:terms.conditionformat_date_column8_option2}}</option>
+                                                <option value="underline">{{html:terms.conditionformat_date_column8_option3}}</option>
+                                                <option value="line-through">{{html:terms.conditionformat_date_column8_option4}}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="kintoneplugin-table-td-operation conditionformat-plugin-column9">
+                            <button type="button" class="kintoneplugin-button-add-row-image addList" title="Add row"></button>
+                            <button type="button" class="kintoneplugin-button-remove-row-image removeList" title="Delete this row"></button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="block">
+        <button class="kintoneplugin-button-dialog-ok" id="conditionformat-submit" type="button">{{html:terms.plugin_submit}}</button>
+        <button class="kintoneplugin-button-dialog-cancel" id="conditionformat-cancel" type="button">{{html:terms.plugin_cancel}}</button>
+    </div>
 </div>

--- a/examples/conditionformat2/html/config.html
+++ b/examples/conditionformat2/html/config.html
@@ -44,7 +44,6 @@
                                         <div class="kintoneplugin-select">
                                             <select class="cf-plugin-column1">
                                                 <option value="">-----</option>
-                                                <option value="status_process_management">{{html:terms.cf_text_column1_option1}}</option>
                                             </select>
                                         </div>
                                     </div>
@@ -88,7 +87,6 @@
                                         <div class="kintoneplugin-select">
                                             <select class="cf-plugin-column4">
                                                 <option value="">-----</option>
-                                                <option value="status_process_management">{{html:terms.cf_text_column4_option1}}</option>
                                             </select>
                                         </div>
                                     </div>
@@ -251,7 +249,6 @@
                                         <div class="kintoneplugin-select">
                                             <select class="cf-plugin-column4">
                                                 <option value="">-----</option>
-                                                <option value="status_process_management">{{html:terms.cf_date_column4_option1}}</option>
                                             </select>
                                         </div>
                                     </div>

--- a/examples/conditionformat2/js/config.js
+++ b/examples/conditionformat2/js/config.js
@@ -6,6 +6,7 @@
  */
 
 jQuery.noConflict();
+
 (function($, PLUGIN_ID) {
     "use strict";
 
@@ -249,21 +250,17 @@ jQuery.noConflict();
                     val(CONF["text_row" + ti]['targetsize']);
                 $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column8").
                     val(CONF["text_row" + ti]['targetfont']);
-                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column5")[0].
-                    setAttribute("style", "color:" + CONF["text_row" + ti]['targetcolor']);
-                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column6")[0].
-                    setAttribute("style", "color:" + CONF["text_row" + ti]['targetbgcolor']);
                 $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column5").
-                    parent('div').find('i')[0].setAttribute(
-                        "style", "border-bottom-color:" + CONF["text_row" + ti]['targetcolor']
-                );
+                    css("color", CONF["text_row" + ti]['targetcolor']);
                 $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column6").
-                    parent('div').find('i')[0].setAttribute(
-                        "style", "border-bottom-color:" + CONF["text_row" + ti]['targetbgcolor']
-                );
+                    css("background-color", CONF["text_row" + ti]['targetbgcolor']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column5").
+                    parent('div').find('i').css("border-bottom-color", CONF["text_row" + ti]['targetcolor']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column6").
+                    parent('div').find('i').css("border-bottom-color", CONF["text_row" + ti]['targetbgcolor']);
                 $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column5-color").
                     val(CONF["text_row" + ti]['targetcolor']);
-                if (CONF["text_row" + ti]['targetcolor'] !== "#") {
+                if (CONF["text_row" + ti]['targetbgcolor'] !== "#") {
                     $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column6-color").
                         val(CONF["text_row" + ti]['targetbgcolor']);
                 } else {
@@ -292,21 +289,17 @@ jQuery.noConflict();
                     val(CONF["date_row" + di]['targetsize']);
                 $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column8").
                     val(CONF["date_row" + di]['targetfont']);
-                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column5")[0].
-                    setAttribute("style", "color:" + CONF["date_row" + di]['targetcolor']);
-                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column6")[0].
-                    setAttribute("style", "color:" + CONF["date_row" + di]['targetbgcolor']);
                 $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column5").
-                    parent('div').find('i')[0].setAttribute(
-                        "style", "border-bottom-color:" + CONF["date_row" + di]['targetcolor']
-                );
+                    css("color", CONF["date_row" + di]['targetcolor']);
                 $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column6").
-                    parent('div').find('i')[0].setAttribute(
-                        "style", "border-bottom-color:" + CONF["date_row" + di]['targetbgcolor']
-                );
+                    css("background-color", CONF["date_row" + di]['targetbgcolor']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column5").
+                    parent('div').find('i').css("border-bottom-color", CONF["date_row" + di]['targetcolor']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column6").
+                    parent('div').find('i').css("border-bottom-color", CONF["date_row" + di]['targetbgcolor']);
                 $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column5-color").
                     val(CONF["date_row" + di]['targetcolor']);
-                if (CONF["date_row" + di]['targetcolor'] !== "#") {
+                if (CONF["date_row" + di]['targetbgcolor'] !== "#") {
                     $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column6-color").
                         val(CONF["date_row" + di]['targetbgcolor']);
                 } else {
@@ -388,15 +381,15 @@ jQuery.noConflict();
 
         //Change color
         $(".cf-plugin-column5").change(function() {
-            $(this)[0].setAttribute("style", "color:" + $(this).val());
-            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + $(this).val());
+            $(this).css("color", $(this).val());
+            $(this).parent('div').find('i').css("border-bottom-color", $(this).val());
             return true;
         });
 
         //Change backgroundcolor
         $(".cf-plugin-column6").change(function() {
-            $(this)[0].setAttribute("style", "background-color:" + $(this).val());
-            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + $(this).val());
+            $(this).css("background-color", $(this).val());
+            $(this).parent('div').find('i').css("border-bottom-color", $(this).val());
             return true;
         });
 
@@ -405,8 +398,8 @@ jQuery.noConflict();
             var color_code = $(this).parent('div').find('input[type="color"]').val();
             var $el = $(this).parent('div').find('input[type="text"]');
             $el.val(color_code);
-            $el[0].setAttribute("style", "color:" + color_code);
-            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + color_code);
+            $el.css("color", color_code);
+            $(this).parent('div').find('i').css("border-bottom-color", $(this).val());
             return true;
         });
 
@@ -415,8 +408,8 @@ jQuery.noConflict();
             var color_code = $(this).parent('div').find('input[type="color"]').val();
             var $el = $(this).parent('div').find('input[type="text"]');
             $el.val(color_code);
-            $el[0].setAttribute("style", "background-color:" + color_code);
-            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + color_code);
+            $el.css('background-color', color_code);
+            $(this).parent('div').find('i').css("border-bottom-color", $(this).val());
             return true;
         });
 
@@ -438,7 +431,7 @@ jQuery.noConflict();
 
         // Remove Row
         $(".removeList").click(function() {
-            $(this).parent().parent().remove();
+            $(this).parent('td').parent('tr').remove();
             checkRowNumber();
         });
 

--- a/examples/conditionformat2/js/config.js
+++ b/examples/conditionformat2/js/config.js
@@ -23,190 +23,190 @@ jQuery.noConflict();
     $(document).ready(function() {
         var terms = {
             'ja': {
-                'conditionformat_text_title': '文字条件書式',
-                'conditionformat_date_title': '日付条件書式',
-                'conditionformat_text_column1': '書式条件フィールド',
-                'conditionformat_text_column2': '条件式',
-                'conditionformat_text_column3': '条件値',
-                'conditionformat_text_column4': '書式変更フィールド',
-                'conditionformat_text_column5': '文字色',
-                'conditionformat_text_column6': '背景色',
-                'conditionformat_text_column7': '文字サイズ',
-                'conditionformat_text_column8': '文字装飾',
-                'conditionformat_text_column1_option1': 'ステータス(プロセス管理)',
-                'conditionformat_text_column2_option1': '条件値を含む',
-                'conditionformat_text_column2_option2': '条件値を含まない',
-                'conditionformat_text_column2_option3': '=(等しい)',
-                'conditionformat_text_column2_option4': '≠(等しくない)',
-                'conditionformat_text_column2_option5': '≦(以下)',
-                'conditionformat_text_column2_option6': '<(より小さい)',
-                'conditionformat_text_column2_option7': '≧(以上)',
-                'conditionformat_text_column2_option8': '>(より大きい)',
-                'conditionformat_text_column4_option1': 'ステータス(プロセス管理)',
-                'conditionformat_text_column7_option1': '変更なし',
-                'conditionformat_text_column7_option2': '小さい',
-                'conditionformat_text_column7_option3': 'やや小さい',
-                'conditionformat_text_column7_option4': 'やや大きい',
-                'conditionformat_text_column7_option5': '大きい',
-                'conditionformat_text_column8_option1': '変更なし',
-                'conditionformat_text_column8_option2': '太字',
-                'conditionformat_text_column8_option3': '下線',
-                'conditionformat_text_column8_option4': '打ち消し線',
-                'conditionformat_date_column1': '書式条件フィールド',
-                'conditionformat_date_column2': '条件式',
-                'conditionformat_date_column3': '条件値',
-                'conditionformat_date_column4': '書式変更フィールド',
-                'conditionformat_date_column5': '文字色',
-                'conditionformat_date_column6': '背景色',
-                'conditionformat_date_column7': '文字サイズ',
-                'conditionformat_date_column8': '文字装飾',
-                'conditionformat_date_column2_desc1': '今日から',
-                'conditionformat_date_column2_desc2': '日',
-                'conditionformat_date_column2_option1': '=(等しい)',
-                'conditionformat_date_column2_option2': '≠(等しくない)',
-                'conditionformat_date_column2_option3': '≦(以前)',
-                'conditionformat_date_column2_option4': '<(より前)',
-                'conditionformat_date_column2_option5': '≧(以後)',
-                'conditionformat_date_column2_option6': '>(より後)',
-                'conditionformat_date_column3_option1': '前',
-                'conditionformat_date_column3_option2': '後',
-                'conditionformat_date_column4_option1': 'ステータス(プロセス管理)',
-                'conditionformat_date_column7_option1': '変更なし',
-                'conditionformat_date_column7_option2': '小さい',
-                'conditionformat_date_column7_option3': 'やや小さい',
-                'conditionformat_date_column7_option4': 'やや大きい',
-                'conditionformat_date_column7_option5': '大きい',
-                'conditionformat_date_column8_option1': '変更なし',
-                'conditionformat_date_column8_option2': '太字',
-                'conditionformat_date_column8_option3': '下線',
-                'conditionformat_date_column8_option4': '打ち消し線',
-                'plugin_submit': '     保存   ',
-                'plugin_cancel': '  キャンセル   ',
-                'required_field': '必須項目が入力されていません。'
+                'cf_text_title': '文字条件書式',
+                'cf_date_title': '日付条件書式',
+                'cf_text_column1': '書式条件フィールド',
+                'cf_text_column2': '条件式',
+                'cf_text_column3': '条件値',
+                'cf_text_column4': '書式変更フィールド',
+                'cf_text_column5': '文字色',
+                'cf_text_column6': '背景色',
+                'cf_text_column7': '文字サイズ',
+                'cf_text_column8': '文字装飾',
+                'cf_text_column1_option1': 'ステータス(プロセス管理)',
+                'cf_text_column2_option1': '条件値を含む',
+                'cf_text_column2_option2': '条件値を含まない',
+                'cf_text_column2_option3': '=(等しい)',
+                'cf_text_column2_option4': '≠(等しくない)',
+                'cf_text_column2_option5': '≦(以下)',
+                'cf_text_column2_option6': '<(より小さい)',
+                'cf_text_column2_option7': '≧(以上)',
+                'cf_text_column2_option8': '>(より大きい)',
+                'cf_text_column4_option1': 'ステータス(プロセス管理)',
+                'cf_text_column7_option1': '変更なし',
+                'cf_text_column7_option2': '小さい',
+                'cf_text_column7_option3': 'やや小さい',
+                'cf_text_column7_option4': 'やや大きい',
+                'cf_text_column7_option5': '大きい',
+                'cf_text_column8_option1': '変更なし',
+                'cf_text_column8_option2': '太字',
+                'cf_text_column8_option3': '下線',
+                'cf_text_column8_option4': '打ち消し線',
+                'cf_date_column1': '書式条件フィールド',
+                'cf_date_column2': '条件式',
+                'cf_date_column3': '条件値',
+                'cf_date_column4': '書式変更フィールド',
+                'cf_date_column5': '文字色',
+                'cf_date_column6': '背景色',
+                'cf_date_column7': '文字サイズ',
+                'cf_date_column8': '文字装飾',
+                'cf_date_column2_desc1': '今日から',
+                'cf_date_column2_desc2': '日',
+                'cf_date_column2_option1': '=(等しい)',
+                'cf_date_column2_option2': '≠(等しくない)',
+                'cf_date_column2_option3': '≦(以前)',
+                'cf_date_column2_option4': '<(より前)',
+                'cf_date_column2_option5': '≧(以後)',
+                'cf_date_column2_option6': '>(より後)',
+                'cf_date_column3_option1': '前',
+                'cf_date_column3_option2': '後',
+                'cf_date_column4_option1': 'ステータス(プロセス管理)',
+                'cf_date_column7_option1': '変更なし',
+                'cf_date_column7_option2': '小さい',
+                'cf_date_column7_option3': 'やや小さい',
+                'cf_date_column7_option4': 'やや大きい',
+                'cf_date_column7_option5': '大きい',
+                'cf_date_column8_option1': '変更なし',
+                'cf_date_column8_option2': '太字',
+                'cf_date_column8_option3': '下線',
+                'cf_date_column8_option4': '打ち消し線',
+                'cf_plugin_submit': '     保存   ',
+                'cf_plugin_cancel': '  キャンセル   ',
+                'cf_required_field': '必須項目が入力されていません。'
             },
             'en': {
-                'conditionformat_text_title': 'Text Format Conditions',
-                'conditionformat_date_title': 'Date Format Conditions',
-                'conditionformat_text_column1': 'Field (condition)',
-                'conditionformat_text_column2': 'Condition',
-                'conditionformat_text_column3': 'Value',
-                'conditionformat_text_column4': 'Field (target)',
-                'conditionformat_text_column5': 'Font Color',
-                'conditionformat_text_column6': 'Background Color',
-                'conditionformat_text_column7': 'Font Size',
-                'conditionformat_text_column8': 'Style',
-                'conditionformat_text_column1_option1': 'Status(Process Management)',
-                'conditionformat_text_column2_option1': 'includes',
-                'conditionformat_text_column2_option2': 'doesn\'t include',
-                'conditionformat_text_column2_option3': '=',
-                'conditionformat_text_column2_option4': '≠',
-                'conditionformat_text_column2_option5': '≦',
-                'conditionformat_text_column2_option6': '<',
-                'conditionformat_text_column2_option7': '≧',
-                'conditionformat_text_column2_option8': '>',
-                'conditionformat_text_column4_option1': 'Status(Process Management)',
-                'conditionformat_text_column7_option1': 'Normal',
-                'conditionformat_text_column7_option2': 'Very Small',
-                'conditionformat_text_column7_option3': 'Small',
-                'conditionformat_text_column7_option4': 'Large',
-                'conditionformat_text_column7_option5': 'Very Large',
-                'conditionformat_text_column8_option1': 'Normal',
-                'conditionformat_text_column8_option2': 'Bold',
-                'conditionformat_text_column8_option3': 'Underline',
-                'conditionformat_text_column8_option4': 'Strikethrough',
-                'conditionformat_date_column1': 'Field (condition)',
-                'conditionformat_date_column2': 'Condition',
-                'conditionformat_date_column3': 'Value',
-                'conditionformat_date_column4': 'Field (target)',
-                'conditionformat_date_column5': 'Font Color',
-                'conditionformat_date_column6': 'Background Color',
-                'conditionformat_date_column7': 'Font Size',
-                'conditionformat_date_column8': 'Style',
-                'conditionformat_date_column2_desc1': '',
-                'conditionformat_date_column2_desc2': 'days',
-                'conditionformat_date_column2_option1': '=',
-                'conditionformat_date_column2_option2': '≠',
-                'conditionformat_date_column2_option3': '≦',
-                'conditionformat_date_column2_option4': '<',
-                'conditionformat_date_column2_option5': '≧',
-                'conditionformat_date_column2_option6': '>',
-                'conditionformat_date_column3_option1': 'before today',
-                'conditionformat_date_column3_option2': 'after today',
-                'conditionformat_date_column4_option1': 'Status(Process Management)',
-                'conditionformat_date_column7_option1': 'Normal',
-                'conditionformat_date_column7_option2': 'Very Small',
-                'conditionformat_date_column7_option3': 'Small',
-                'conditionformat_date_column7_option4': 'Large',
-                'conditionformat_date_column7_option5': 'Very Large',
-                'conditionformat_date_column8_option1': 'Normal',
-                'conditionformat_date_column8_option2': 'Bold',
-                'conditionformat_date_column8_option3': 'Underline',
-                'conditionformat_date_column8_option4': 'Strikethrough',
-                'plugin_submit': '     Save   ',
-                'plugin_cancel': '  Cancel   ',
-                'required_field': 'Required field is empty.'
+                'cf_text_title': 'Text Format Conditions',
+                'cf_date_title': 'Date Format Conditions',
+                'cf_text_column1': 'Field (condition)',
+                'cf_text_column2': 'Condition',
+                'cf_text_column3': 'Value',
+                'cf_text_column4': 'Field (target)',
+                'cf_text_column5': 'Font Color',
+                'cf_text_column6': 'Background Color',
+                'cf_text_column7': 'Font Size',
+                'cf_text_column8': 'Style',
+                'cf_text_column1_option1': 'Status(Process Management)',
+                'cf_text_column2_option1': 'includes',
+                'cf_text_column2_option2': 'doesn\'t include',
+                'cf_text_column2_option3': '=',
+                'cf_text_column2_option4': '≠',
+                'cf_text_column2_option5': '≦',
+                'cf_text_column2_option6': '<',
+                'cf_text_column2_option7': '≧',
+                'cf_text_column2_option8': '>',
+                'cf_text_column4_option1': 'Status(Process Management)',
+                'cf_text_column7_option1': 'Normal',
+                'cf_text_column7_option2': 'Very Small',
+                'cf_text_column7_option3': 'Small',
+                'cf_text_column7_option4': 'Large',
+                'cf_text_column7_option5': 'Very Large',
+                'cf_text_column8_option1': 'Normal',
+                'cf_text_column8_option2': 'Bold',
+                'cf_text_column8_option3': 'Underline',
+                'cf_text_column8_option4': 'Strikethrough',
+                'cf_date_column1': 'Field (condition)',
+                'cf_date_column2': 'Condition',
+                'cf_date_column3': 'Value',
+                'cf_date_column4': 'Field (target)',
+                'cf_date_column5': 'Font Color',
+                'cf_date_column6': 'Background Color',
+                'cf_date_column7': 'Font Size',
+                'cf_date_column8': 'Style',
+                'cf_date_column2_desc1': '',
+                'cf_date_column2_desc2': 'days',
+                'cf_date_column2_option1': '=',
+                'cf_date_column2_option2': '≠',
+                'cf_date_column2_option3': '≦',
+                'cf_date_column2_option4': '<',
+                'cf_date_column2_option5': '≧',
+                'cf_date_column2_option6': '>',
+                'cf_date_column3_option1': 'before today',
+                'cf_date_column3_option2': 'after today',
+                'cf_date_column4_option1': 'Status(Process Management)',
+                'cf_date_column7_option1': 'Normal',
+                'cf_date_column7_option2': 'Very Small',
+                'cf_date_column7_option3': 'Small',
+                'cf_date_column7_option4': 'Large',
+                'cf_date_column7_option5': 'Very Large',
+                'cf_date_column8_option1': 'Normal',
+                'cf_date_column8_option2': 'Bold',
+                'cf_date_column8_option3': 'Underline',
+                'cf_date_column8_option4': 'Strikethrough',
+                'cf_plugin_submit': '     Save   ',
+                'cf_plugin_cancel': '  Cancel   ',
+                'cf_required_field': 'Required field is empty.'
             },
             'zh': {
-                'conditionformat_text_title': '文字条件格式',
-                'conditionformat_date_title': '日期条件格式',
-                'conditionformat_text_column1': '条件字段',
-                'conditionformat_text_column2': '条件公式',
-                'conditionformat_text_column3': '条件值',
-                'conditionformat_text_column4': '要更改格式的字段',
-                'conditionformat_text_column5': '字体颜色',
-                'conditionformat_text_column6': '背景色',
-                'conditionformat_text_column7': '文字大小',
-                'conditionformat_text_column8': '字体装饰',
-                'conditionformat_text_column1_option1': '状态(流程管理)',
-                'conditionformat_text_column2_option1': '包含条件值',
-                'conditionformat_text_column2_option2': '不包含条件值',
-                'conditionformat_text_column2_option3': '=(等于)',
-                'conditionformat_text_column2_option4': '≠(不等于)',
-                'conditionformat_text_column2_option5': '≦(小于或等于)',
-                'conditionformat_text_column2_option6': '<(小于)',
-                'conditionformat_text_column2_option7': '≧(大于或等于)',
-                'conditionformat_text_column2_option8': '>(大于)',
-                'conditionformat_text_column4_option1': '状态(流程管理)',
-                'conditionformat_text_column7_option1': '不更改',
-                'conditionformat_text_column7_option2': '小',
-                'conditionformat_text_column7_option3': '稍小',
-                'conditionformat_text_column7_option4': '稍大',
-                'conditionformat_text_column7_option5': '大',
-                'conditionformat_text_column8_option1': '不更改',
-                'conditionformat_text_column8_option2': '粗体',
-                'conditionformat_text_column8_option3': '下划线',
-                'conditionformat_text_column8_option4': '删除线',
-                'conditionformat_date_column1': '条件字段',
-                'conditionformat_date_column2': '条件公式',
-                'conditionformat_date_column3': '条件值',
-                'conditionformat_date_column4': '要更改格式的字段',
-                'conditionformat_date_column5': '字体颜色',
-                'conditionformat_date_column6': '背景色',
-                'conditionformat_date_column7': '字体大小',
-                'conditionformat_date_column8': '字体装饰',
-                'conditionformat_date_column2_desc1': '今日起',
-                'conditionformat_date_column2_desc2': '天',
-                'conditionformat_date_column2_option1': '=(等于)',
-                'conditionformat_date_column2_option2': '≠(不等于)',
-                'conditionformat_date_column2_option3': '≦(以前)',
-                'conditionformat_date_column2_option4': '<(早于)',
-                'conditionformat_date_column2_option5': '≧(以后)',
-                'conditionformat_date_column2_option6': '>(晚于)',
-                'conditionformat_date_column3_option1': '前',
-                'conditionformat_date_column3_option2': '后',
-                'conditionformat_date_column4_option1': '状态(流程管理)',
-                'conditionformat_date_column7_option1': '不更改',
-                'conditionformat_date_column7_option2': '小',
-                'conditionformat_date_column7_option3': '稍小',
-                'conditionformat_date_column7_option4': '稍大',
-                'conditionformat_date_column7_option5': '大',
-                'conditionformat_date_column8_option1': '不更改',
-                'conditionformat_date_column8_option2': '粗体',
-                'conditionformat_date_column8_option3': '下划线',
-                'conditionformat_date_column8_option4': '删除线',
-                'plugin_submit': '     保存   ',
-                'plugin_cancel': '  取消   ',
-                'required_field': '有必填项未填写。'
+                'cf_text_title': '文字条件格式',
+                'cf_date_title': '日期条件格式',
+                'cf_text_column1': '条件字段',
+                'cf_text_column2': '条件公式',
+                'cf_text_column3': '条件值',
+                'cf_text_column4': '要更改格式的字段',
+                'cf_text_column5': '字体颜色',
+                'cf_text_column6': '背景色',
+                'cf_text_column7': '文字大小',
+                'cf_text_column8': '字体装饰',
+                'cf_text_column1_option1': '状态(流程管理)',
+                'cf_text_column2_option1': '包含条件值',
+                'cf_text_column2_option2': '不包含条件值',
+                'cf_text_column2_option3': '=(等于)',
+                'cf_text_column2_option4': '≠(不等于)',
+                'cf_text_column2_option5': '≦(小于或等于)',
+                'cf_text_column2_option6': '<(小于)',
+                'cf_text_column2_option7': '≧(大于或等于)',
+                'cf_text_column2_option8': '>(大于)',
+                'cf_text_column4_option1': '状态(流程管理)',
+                'cf_text_column7_option1': '不更改',
+                'cf_text_column7_option2': '小',
+                'cf_text_column7_option3': '稍小',
+                'cf_text_column7_option4': '稍大',
+                'cf_text_column7_option5': '大',
+                'cf_text_column8_option1': '不更改',
+                'cf_text_column8_option2': '粗体',
+                'cf_text_column8_option3': '下划线',
+                'cf_text_column8_option4': '删除线',
+                'cf_date_column1': '条件字段',
+                'cf_date_column2': '条件公式',
+                'cf_date_column3': '条件值',
+                'cf_date_column4': '要更改格式的字段',
+                'cf_date_column5': '字体颜色',
+                'cf_date_column6': '背景色',
+                'cf_date_column7': '字体大小',
+                'cf_date_column8': '字体装饰',
+                'cf_date_column2_desc1': '今日起',
+                'cf_date_column2_desc2': '天',
+                'cf_date_column2_option1': '=(等于)',
+                'cf_date_column2_option2': '≠(不等于)',
+                'cf_date_column2_option3': '≦(以前)',
+                'cf_date_column2_option4': '<(早于)',
+                'cf_date_column2_option5': '≧(以后)',
+                'cf_date_column2_option6': '>(晚于)',
+                'cf_date_column3_option1': '前',
+                'cf_date_column3_option2': '后',
+                'cf_date_column4_option1': '状态(流程管理)',
+                'cf_date_column7_option1': '不更改',
+                'cf_date_column7_option2': '小',
+                'cf_date_column7_option3': '稍小',
+                'cf_date_column7_option4': '稍大',
+                'cf_date_column7_option5': '大',
+                'cf_date_column8_option1': '不更改',
+                'cf_date_column8_option2': '粗体',
+                'cf_date_column8_option3': '下划线',
+                'cf_date_column8_option4': '删除线',
+                'cf_plugin_submit': '     保存   ',
+                'cf_plugin_cancel': '  取消   ',
+                'cf_required_field': '有必填项未填写。'
             }
         };
 
@@ -214,9 +214,9 @@ jQuery.noConflict();
         var lang = kintone.getLoginUser().language;
         var i18n = (lang in terms) ? terms[lang] : terms['en'];
 
-        var configHtml = $('#conditionformat-plugin').html();
+        var configHtml = $('#cf-plugin').html();
         var tmpl = $.templates(configHtml);
-        $('div#conditionformat-plugin').html(tmpl.render({'terms': i18n}));
+        $('div#cf-plugin').html(tmpl.render({'terms': i18n}));
 
         function escapeHtml(htmlstr) {
             return htmlstr.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
@@ -224,102 +224,117 @@ jQuery.noConflict();
         }
 
         function checkRowNumber() {
-            if ($("#conditionformat-plugin-text-tbody > tr").length === 2) {
-                $("#conditionformat-plugin-text-tbody > tr .removeList").eq(1).hide();
+            if ($("#cf-plugin-text-tbody > tr").length === 2) {
+                $("#cf-plugin-text-tbody > tr .removeList").eq(1).hide();
             } else {
-                $("#conditionformat-plugin-text-tbody > tr .removeList").eq(1).show();
+                $("#cf-plugin-text-tbody > tr .removeList").eq(1).show();
             }
 
-            if ($("#conditionformat-plugin-date-tbody > tr").length === 2) {
-                $("#conditionformat-plugin-date-tbody > tr .removeList").eq(1).hide();
+            if ($("#cf-plugin-date-tbody > tr").length === 2) {
+                $("#cf-plugin-date-tbody > tr .removeList").eq(1).hide();
             } else {
-                $("#conditionformat-plugin-date-tbody > tr .removeList").eq(1).show();
+                $("#cf-plugin-date-tbody > tr .removeList").eq(1).show();
             }
+        }
+
+        function setTextDefault() {
+            for (var ti = 1; ti <= TEXT_ROW_NUM; ti++) {
+                $("#cf-plugin-text-tbody > tr").eq(0).clone(true).insertAfter(
+                    $("#cf-plugin-text-tbody > tr").eq(ti - 1)
+                );
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column1").val(CONF["text_row" + ti]['field']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column2").val(CONF["text_row" + ti]['type']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column3").val(CONF["text_row" + ti]['value']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column4").
+                    val(CONF["text_row" + ti]['targetfield']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column5").
+                    val(CONF["text_row" + ti]['targetcolor']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column6").
+                    val(CONF["text_row" + ti]['targetbgcolor']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column7").
+                    val(CONF["text_row" + ti]['targetsize']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column8").
+                    val(CONF["text_row" + ti]['targetfont']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column5")[0].
+                    setAttribute("style", "color:" + CONF["text_row" + ti]['targetcolor']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column6")[0].
+                    setAttribute("style", "color:" + CONF["text_row" + ti]['targetbgcolor']);
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column5").
+                    parent('div').find('i')[0].setAttribute(
+                        "style", "border-bottom-color:" + CONF["text_row" + ti]['targetcolor']
+                );
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column6").
+                    parent('div').find('i')[0].setAttribute(
+                        "style", "border-bottom-color:" + CONF["text_row" + ti]['targetbgcolor']
+                );
+                $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column5-color").
+                    val(CONF["text_row" + ti]['targetcolor']);
+                if (CONF["text_row" + ti]['targetcolor'] !== "#") {
+                    $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column6-color").
+                        val(CONF["text_row" + ti]['targetbgcolor']);
+                } else {
+                    $("#cf-plugin-text-tbody > tr:eq(" + ti + ") .cf-plugin-column6-color").val('#808080');
+                }
+            }
+        }
+
+        function setDateDefault() {
+            for (var di = 1; di <= DATE_ROW_NUM; di++) {
+                $("#cf-plugin-date-tbody > tr").eq(0).clone(true).insertAfter(
+                    $("#cf-plugin-date-tbody > tr").eq(di - 1)
+                );
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column1").val(CONF["date_row" + di]['field']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column2").val(CONF["date_row" + di]['type']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column3").val(CONF["date_row" + di]['value']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column3-select2").
+                    val(CONF["date_row" + di]['type2']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column4").
+                    val(CONF["date_row" + di]['targetfield']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column5").
+                    val(CONF["date_row" + di]['targetcolor']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column6").
+                    val(CONF["date_row" + di]['targetbgcolor']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column7").
+                    val(CONF["date_row" + di]['targetsize']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column8").
+                    val(CONF["date_row" + di]['targetfont']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column5")[0].
+                    setAttribute("style", "color:" + CONF["date_row" + di]['targetcolor']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column6")[0].
+                    setAttribute("style", "color:" + CONF["date_row" + di]['targetbgcolor']);
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column5").
+                    parent('div').find('i')[0].setAttribute(
+                        "style", "border-bottom-color:" + CONF["date_row" + di]['targetcolor']
+                );
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column6").
+                    parent('div').find('i')[0].setAttribute(
+                        "style", "border-bottom-color:" + CONF["date_row" + di]['targetbgcolor']
+                );
+                $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column5-color").
+                    val(CONF["date_row" + di]['targetcolor']);
+                if (CONF["date_row" + di]['targetcolor'] !== "#") {
+                    $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column6-color").
+                        val(CONF["date_row" + di]['targetbgcolor']);
+                } else {
+                    $("#cf-plugin-date-tbody > tr:eq(" + di + ") .cf-plugin-column6-color").val('#808080');
+                }
+            }
+
         }
 
         function setDefault() {
             if (TEXT_ROW_NUM > 0) {
-                for (var ti = 1; ti <= TEXT_ROW_NUM; ti++) {
-                    $("#conditionformat-plugin-text-tbody > tr").eq(0).clone(true).insertAfter(
-                        $("#conditionformat-plugin-text-tbody > tr").eq(ti - 1)
-                    );
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column1").
-                        val(CONF["text_row" + ti]['field']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column2").
-                        val(CONF["text_row" + ti]['type']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column3").
-                        val(CONF["text_row" + ti]['value']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column4").
-                        val(CONF["text_row" + ti]['targetfield']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column5").
-                        val(CONF["text_row" + ti]['targetcolor']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column6").
-                        val(CONF["text_row" + ti]['targetbackgroundcolor']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column7").
-                        val(CONF["text_row" + ti]['targetsize']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column8").
-                        val(CONF["text_row" + ti]['targetfont']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column5")[0].
-                        setAttribute("style", "color:" + CONF["text_row" + ti]['targetcolor']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column6")[0].
-                        setAttribute("style", "color:" + CONF["text_row" + ti]['targetbackgroundcolor']);
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column5").
-                        parent('div').find('i')[0].setAttribute(
-                            "style", "border-bottom-color:" + CONF["text_row" + ti]['targetcolor']
-                    );
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column6").
-                        parent('div').find('i')[0].setAttribute(
-                            "style", "border-bottom-color:" + CONF["text_row" + ti]['targetbackgroundcolor']
-                    );
-                }
+                setTextDefault();
             } else {
                 // Insert Row
-                $("#conditionformat-plugin-text-tbody > tr").eq(0).clone(true).insertAfter(
-                    $("#conditionformat-plugin-text-tbody > tr")
-                ).eq(0);
+                $("#cf-plugin-text-tbody > tr").eq(0).clone(true).insertAfter($("#cf-plugin-text-tbody > tr")).eq(0);
             }
 
             if (DATE_ROW_NUM > 0) {
-                for (var di = 1; di <= DATE_ROW_NUM; di++) {
-                    $("#conditionformat-plugin-date-tbody > tr").eq(0).clone(true).insertAfter(
-                        $("#conditionformat-plugin-date-tbody > tr").eq(di - 1)
-                    );
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column1").
-                        val(CONF["date_row" + di]['field']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column2").
-                        val(CONF["date_row" + di]['type']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column3").
-                        val(CONF["date_row" + di]['value']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column3-select2").
-                        val(CONF["date_row" + di]['type2']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column4").
-                        val(CONF["date_row" + di]['targetfield']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column5").
-                        val(CONF["date_row" + di]['targetcolor']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column6").
-                        val(CONF["date_row" + di]['targetbackgroundcolor']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column7").
-                        val(CONF["date_row" + di]['targetsize']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column8").
-                        val(CONF["date_row" + di]['targetfont']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column5")[0].
-                        setAttribute("style", "color:" + CONF["date_row" + di]['targetcolor']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column6")[0].
-                        setAttribute("style", "color:" + CONF["date_row" + di]['targetbackgroundcolor']);
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column5").
-                        parent('div').find('i')[0].setAttribute(
-                            "style", "border-bottom-color:" + CONF["date_row" + di]['targetcolor']
-                    );
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column6").
-                        parent('div').find('i')[0].setAttribute(
-                            "style", "border-bottom-color:" + CONF["date_row" + di]['targetbackgroundcolor']
-                    );
-                }
+                setDateDefault();
             } else {
                 // Insert Row
-                $("#conditionformat-plugin-date-tbody > tr").eq(0).clone(true).insertAfter(
-                    $("#conditionformat-plugin-date-tbody > tr")
-                ).eq(0);
+                $("#cf-plugin-date-tbody > tr").eq(0).clone(true).insertAfter($("#cf-plugin-date-tbody > tr")).eq(0);
             }
             checkRowNumber();
         }
@@ -344,12 +359,9 @@ jQuery.noConflict();
                         case "MULTI_SELECT":
                             $option.attr("value", escapeHtml(prop.code));
                             $option.text(escapeHtml(prop.label));
-                            $("#conditionformat-plugin-text-tbody > tr:eq(0) .conditionformat-plugin-column1").
-                                append($option.clone());
-                            $("#conditionformat-plugin-text-tbody > tr:eq(0) .conditionformat-plugin-column4").
-                                append($option.clone());
-                            $("#conditionformat-plugin-date-tbody > tr:eq(0) .conditionformat-plugin-column4").
-                                append($option.clone());
+                            $("#cf-plugin-text-tbody > tr:eq(0) .cf-plugin-column1").append($option.clone());
+                            $("#cf-plugin-text-tbody > tr:eq(0) .cf-plugin-column4").append($option.clone());
+                            $("#cf-plugin-date-tbody > tr:eq(0) .cf-plugin-column4").append($option.clone());
                             break;
 
                         case "DATE":
@@ -358,12 +370,9 @@ jQuery.noConflict();
                         case "UPDATED_TIME":
                             $option.attr("value", escapeHtml(prop.code));
                             $option.text(escapeHtml(prop.label));
-                            $("#conditionformat-plugin-text-tbody > tr:eq(0) .conditionformat-plugin-column1").
-                                append($option.clone());
-                            $("#conditionformat-plugin-date-tbody > tr:eq(0) .conditionformat-plugin-column4").
-                                append($option.clone());
-                            $("#conditionformat-plugin-date-tbody > tr:eq(0) .conditionformat-plugin-column1").
-                                append($option.clone());
+                            $("#cf-plugin-text-tbody > tr:eq(0) .cf-plugin-column1").append($option.clone());
+                            $("#cf-plugin-date-tbody > tr:eq(0) .cf-plugin-column4").append($option.clone());
+                            $("#cf-plugin-date-tbody > tr:eq(0) .cf-plugin-column1").append($option.clone());
                             break;
 
                         default :
@@ -374,18 +383,72 @@ jQuery.noConflict();
             });
         }
 
-        function showErrorMessages(type, error_num, row_num) {
+        //Change color
+        $(".cf-plugin-column5").change(function() {
+            $(this)[0].setAttribute("style", "color:" + $(this).val());
+            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + $(this).val());
+            return true;
+        });
+
+        //Change backgroundcolor
+        $(".cf-plugin-column6").change(function() {
+            $(this)[0].setAttribute("style", "background-color:" + $(this).val());
+            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + $(this).val());
+            return true;
+        });
+
+        //Change color
+        $(".cf-plugin-column5-color").change(function() {
+            var color_code = $(this).parent('div').find('input[type="color"]').val();
+            var $el = $(this).parent('div').find('input[type="text"]');
+            $el.val(color_code);
+            $el[0].setAttribute("style", "color:" + color_code);
+            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + color_code);
+            return true;
+        });
+
+        //Change color
+        $(".cf-plugin-column6-color").change(function() {
+            var color_code = $(this).parent('div').find('input[type="color"]').val();
+            var $el = $(this).parent('div').find('input[type="text"]');
+            $el.val(color_code);
+            $el[0].setAttribute("style", "background-color:" + color_code);
+            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + color_code);
+            return true;
+        });
+
+        //Color picker
+        $(".color-paint-brush").click(function() {
+            $($(this).parents('td')[0]).find('input[type="color"]').click();
+        });
+
+        //Add Row
+        $("#cf-plugin-text-tbody .addList").click(function() {
+            $("#cf-plugin-text-tbody > tr").eq(0).clone(true).insertAfter($(this).parent().parent());
+            checkRowNumber();
+        });
+
+        $("#cf-plugin-date-tbody .addList").click(function() {
+            $("#cf-plugin-date-tbody > tr").eq(0).clone(true).insertAfter($(this).parent().parent());
+            checkRowNumber();
+        });
+
+        // Remove Row
+        $(".removeList").click(function() {
+            $(this).parent().parent().remove();
+            checkRowNumber();
+        });
+
+        function createErrorMessage(type, error_num, row_num) {
             var user_lang = kintone.getLoginUser().language;
-            var messages = {
+            var error_messages = {
                 'ja': {
                     'text': {
                         "1": "文字条件書式の" + row_num + "行目の必須入力項目を入力してください",
                         "2": "文字条件書式の" + row_num + "行目の文字色には\nカラーコード「#000000-#FFFFFF」を入力してください",
                         "3": "文字条件書式の" + row_num + "行目の背景色には\nカラーコード「#000000-#FFFFFF」を入力してください",
-                        "4": "文字条件書式の" + row_num + "行目の条件値または色に\n" +
-                                "HTML特殊文字(&, <, >, \", \')を入力することはできません",
-                        "5": "文字条件書式の" + row_num + "行目に「ステータス(プロセス管理)」を追加するには\n" +
-                                "プロセス管理の設定を有効にしてください"
+                        "4": "文字条件書式の" + row_num + "行目の条件値または色に\n" + "HTML特殊文字(&, <, >, \", \')を入力することはできません",
+                        "5": "文字条件書式の" + row_num + "行目に「ステータス(プロセス管理)」を追加するには\n" + "プロセス管理の設定を有効にしてください"
                     },
                     'date': {
                         "1": "日付条件書式の" + row_num + "行目の必須入力項目を入力してください",
@@ -440,164 +503,149 @@ jQuery.noConflict();
                     }
                 }
             };
-            alert(messages[user_lang][type][error_num]);
+            return error_messages[user_lang][type][error_num];
+        }
+
+        function checkConfigTextValues(config, pm_type) {
+            var text_row_num = Number(config["text_row_number"]);
+            for (var ct = 1; ct <= text_row_num; ct++) {
+                var text = JSON.parse(config["text_row" + ct]);
+                if ((text.field === "" || text.type === "" || text.targetfield === "") &&
+                    !(text.field === "" && text.type === "" && text.targetfield === "")) {
+                    throw new Error(createErrorMessage("text", "1", ct));
+                }
+
+                if (text.targetcolor.slice(0, 1) !== "#") {
+                    throw new Error(createErrorMessage("text", "2", ct));
+                }
+
+                if (text.targetcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
+                    if (text.targetcolor !== "#000000") {
+                        throw new Error(createErrorMessage("text", "2", ct));
+                    }
+                }
+
+                if (text.targetbgcolor.slice(0, 1) !== "#") {
+                    throw new Error(createErrorMessage("text", "3", ct));
+                }
+
+                if (text.targetbgcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
+                    if (text.targetbgcolor !== "#") {
+                        throw new Error(createErrorMessage("text", "3", ct));
+                    }
+                }
+                if (text.value.match(/\&|<|\>|\"|\'/g) !== null ||
+                    text.targetcolor.match(/\&|<|\>|\"|\'/g) !== null ||
+                    text.targetbgcolor.match(/\&|<|\>|\"|\'/g) !== null) {
+                    throw new Error(createErrorMessage("text", "4", ct));
+                }
+                if (!pm_type &&
+                    (text.field === "status_process_management" || text.targetfield === "status_process_management")) {
+                    throw new Error(createErrorMessage("text", "5", ct));
+                }
+            }
+        }
+
+        function checkConfigDateValues(config, pm_type) {
+            var date_row_num = Number(config["date_row_number"]);
+            for (var cd = 1; cd <= date_row_num; cd++) {
+                var date = JSON.parse(config["date_row" + cd]);
+                if ((date.field === "" || date.type === "" || date.targetfield === "") &&
+                    !(date.field === "" && date.type === "" && date.targetfield === "")) {
+                    throw new Error(createErrorMessage("date", "1", cd));
+                }
+                if (isNaN(date.value)) {
+                    throw new Error(createErrorMessage("date", "2", cd));
+                }
+                if (date.value.indexOf(".") > -1) {
+                    throw new Error(createErrorMessage("date", "3", cd));
+                }
+                if (date.targetcolor.slice(0, 1) !== "#") {
+                    throw new Error(createErrorMessage("date", "4", cd));
+                }
+                if (date.targetcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
+                    if (date.targetcolor !== "#000000") {
+                        throw new Error(createErrorMessage("date", "4", cd));
+                    }
+                }
+                if (date.targetbgcolor.slice(0, 1) !== "#") {
+                    throw new Error(createErrorMessage("date", "5", cd));
+                }
+                if (date.targetbgcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
+                    if (date.targetbgcolor !== "#") {
+                        throw new Error(createErrorMessage("date", "5", cd));
+                    }
+                }
+                if (date.value.match(/\&|<|\>|\"|\'/g) !== null ||
+                    date.targetcolor.match(/\&|<|\>|\"|\'/g) !== null ||
+                    date.targetbgcolor.match(/\&|<|\>|\"|\'/g) !== null) {
+                    throw new Error(createErrorMessage("date", "6", cd));
+                }
+                if (!pm_type && date.targetfield === "status_process_management") {
+                    throw new Error(createErrorMessage("date", "7", cd));
+                }
+            }
+        }
+
+        function checkConfigValues(config, pm_type) {
+            checkConfigTextValues(config, pm_type);
+            checkConfigDateValues(config, pm_type);
         }
 
         function getValues(type, num) {
             switch (type) {
                 case "text":
                     return {
-                        "field": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column1").val(),
-                        "type": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column2").val(),
-                        "value": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column3").val(),
-                        "targetfield": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column4").val(),
-                        "targetcolor": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column5").val(),
-                        "targetbackgroundcolor": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column6").val(),
-                        "targetsize": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column7").val(),
-                        "targetfont": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column8").val()
+                        "field": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column1").val(),
+                        "type": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column2").val(),
+                        "value": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column3").val(),
+                        "targetfield": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column4").val(),
+                        "targetcolor": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column5").val(),
+                        "targetbgcolor": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column6").val(),
+                        "targetsize": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column7").val(),
+                        "targetfont": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column8").val()
                     };
                 case "date":
                     return {
-                        "field": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column1").val(),
-                        "type": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column2").val(),
-                        "value": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column3").val(),
-                        "type2": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column3-select2").val(),
-                        "targetfield": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column4").val(),
-                        "targetcolor": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column5").val(),
-                        "targetbackgroundcolor": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column6").val(),
-                        "targetsize": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column7").val(),
-                        "targetfont": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
-                                ") .conditionformat-plugin-column8").val()
+                        "field": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column1").val(),
+                        "type": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column2").val(),
+                        "value": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column3").val(),
+                        "type2": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column3-select2").val(),
+                        "targetfield": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column4").val(),
+                        "targetcolor": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column5").val(),
+                        "targetbgcolor": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column6").val(),
+                        "targetsize": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column7").val(),
+                        "targetfont": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column8").val()
                     };
                 default:
                     return "";
             }
         }
-        function checkTextValues(config, pm_type) {
-            var text_row_num = $("#conditionformat-plugin-text-tbody > tr").length - 1;
+
+        function createConfig() {
+            var config = {};
+            var text_row_num = $("#cf-plugin-text-tbody > tr").length - 1;
             for (var ct = 1; ct <= text_row_num; ct++) {
                 var text = getValues("text", ct);
                 if (text.field === "" && text.type === "" && text.targetfield === "") {
-                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ct + ")").remove();
+                    //Remove unnecessary row
+                    $("#cf-plugin-text-tbody > tr:eq(" + ct + ")").remove();
                     text_row_num = text_row_num - 1;
                     ct--;
                     continue;
                 }
-
-                if ((text.field === "" || text.type === "" || text.targetfield === "") &&
-                    !(text.field === "" && text.type === "" && text.targetfield === "")) {
-                    showErrorMessages("text", "1", ct);
-                    return false;
-                }
-
-                if (text.targetcolor.slice(0, 1) !== "#") {
-                    showErrorMessages("text", "2", ct);
-                    return false;
-                }
-
-                if (text.targetcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
-                    if (text.targetcolor !== "#000000") {
-                        showErrorMessages("text", "2", ct);
-                        return false;
-                    }
-                }
-
-                if (text.targetbackgroundcolor.slice(0, 1) !== "#") {
-                    showErrorMessages("text", "3", ct);
-                    return false;
-                }
-
-                if (text.targetbackgroundcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
-                    if (text.targetbackgroundcolor !== "#") {
-                        showErrorMessages("text", "3", ct);
-                        return false;
-                    }
-                }
-                if (text.value.match(/\&|<|\>|\"|\'/g) !== null ||
-                    text.targetcolor.match(/\&|<|\>|\"|\'/g) !== null ||
-                    text.targetbackgroundcolor.match(/\&|<|\>|\"|\'/g) !== null) {
-                    showErrorMessages("text", "4", ct);
-                    return false;
-                }
-                if (!pm_type &&
-                    (text.field === "status_process_management" || text.targetfield === "status_process_management")) {
-                    showErrorMessages("text", "5", ct);
-                    return false;
-                }
                 config["text_row" + ct] = JSON.stringify(text);
             }
             config["text_row_number"] = String(text_row_num);
-            return config;
-        }
-
-        function checkDateValues(config, pm_type) {
-            var date_row_num = $("#conditionformat-plugin-date-tbody > tr").length - 1;
+            var date_row_num = $("#cf-plugin-date-tbody > tr").length - 1;
             for (var cd = 1; cd <= date_row_num; cd++) {
                 var date = getValues("date", cd);
                 if (date.field === "" && date.type === "" && date.targetfield === "") {
-                    $("#conditionformat-plugin-date-tbody > tr:eq(" + cd + ")").remove();
+                    //Remove unnecessary row
+                    $("#cf-plugin-date-tbody > tr:eq(" + cd + ")").remove();
                     date_row_num = date_row_num - 1;
                     cd--;
                     continue;
-                }
-                if ((date.field === "" || date.type === "" || date.targetfield === "") &&
-                    !(date.field === "" && date.type === "" && date.targetfield === "")) {
-                    showErrorMessages("date", "1", cd);
-                    return false;
-                }
-                if (isNaN(date.value)) {
-                    showErrorMessages("date", "2", cd);
-                    return false;
-                }
-                if (date.value.indexOf(".") > -1) {
-                    showErrorMessages("date", "3", cd);
-                    return false;
-                }
-                if (date.targetcolor.slice(0, 1) !== "#") {
-                    showErrorMessages("date", "4", cd);
-                    return false;
-                }
-                if (date.targetcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
-                    if (date.targetcolor !== "#000000") {
-                        showErrorMessages("date", "4", cd);
-                        return false;
-                    }
-                }
-                if (date.targetbackgroundcolor.slice(0, 1) !== "#") {
-                    showErrorMessages("date", "5", cd);
-                    return false;
-                }
-                if (date.targetbackgroundcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
-                    if (date.targetbackgroundcolor !== "#") {
-                        showErrorMessages("date", "5", cd);
-                        return false;
-                    }
-                }
-                if (date.value.match(/\&|<|\>|\"|\'/g) !== null ||
-                    date.targetcolor.match(/\&|<|\>|\"|\'/g) !== null ||
-                    date.targetbackgroundcolor.match(/\&|<|\>|\"|\'/g) !== null) {
-                    showErrorMessages("date", "6", cd);
-                    return false;
-                }
-                if (!pm_type && date.targetfield === "status_process_management") {
-                    showErrorMessages("date", "7", cd);
-                    return false;
                 }
                 config["date_row" + cd] = JSON.stringify(getValues("date", cd));
             }
@@ -605,88 +653,26 @@ jQuery.noConflict();
             return config;
         }
 
-        function checkValues(pm_type) {
-            var config = {};
-            config = checkTextValues(config, pm_type);
-            if (!config) { return; }
-
-            config = checkDateValues(config, pm_type);
-            if (!config) { return; }
-
-            //SaveConfig
+        function saveConfig(pm_type) {
+            var config = createConfig();
+            checkConfigValues(config, pm_type);
             kintone.plugin.app.setConfig(config);
         }
 
-        //Change color
-        $(".conditionformat-plugin-column5").change(function() {
-            $(this)[0].setAttribute("style", "color:" + $(this).val());
-            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + $(this).val());
-            return true;
-        });
-
-        //Change backgroundcolor
-        $(".conditionformat-plugin-column6").change(function() {
-            $(this)[0].setAttribute("style", "background-color:" + $(this).val());
-            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + $(this).val());
-            return true;
-        });
-
-        //Change color
-        $(".conditionformat-plugin-column5-color").change(function() {
-            var color_code = $(this).parent('div').find('input[type="color"]').val();
-            var $el = $(this).parent('div').find('input[type="text"]');
-            $el.val(color_code);
-            $el[0].setAttribute("style", "color:" + color_code);
-            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + color_code);
-            return true;
-        });
-
-        //Change color
-        $(".conditionformat-plugin-column6-color").change(function() {
-            var color_code = $(this).parent('div').find('input[type="color"]').val();
-            var $el = $(this).parent('div').find('input[type="text"]');
-            $el.val(color_code);
-            $el[0].setAttribute("style", "background-color:" + color_code);
-            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + color_code);
-            return true;
-        });
-
-        //Color picker
-        $(".color-paint-brush").click(function() {
-            $($(this).parents('td')[0]).find('input[type="color"]').click();
-        });
-
-        //Add Row
-        $("#conditionformat-plugin-text-tbody .addList").click(function() {
-            $("#conditionformat-plugin-text-tbody > tr").eq(0).clone(true).insertAfter(
-                $(this).parent().parent()
-            );
-            checkRowNumber();
-        });
-
-        $("#conditionformat-plugin-date-tbody .addList").click(function() {
-            $("#conditionformat-plugin-date-tbody > tr").eq(0).clone(true).insertAfter(
-                $(this).parent().parent()
-            );
-            checkRowNumber();
-        });
-
-        // Remove Row
-        $(".removeList").click(function() {
-            $(this).parent().parent().remove();
-            checkRowNumber();
-        });
-
         //Save
-        $("#conditionformat-submit").click(function() {
+        $("#cf-submit").click(function() {
             var param2 = {"app": kintone.app.getId()};
             kintone.api(kintone.api.url("/k/v1/preview/app/status", true), "GET", param2, function(resp) {
-                checkValues(resp.enable);
+                try {
+                    saveConfig(resp.enable);
+                } catch(error) {
+                    alert(error.message);
+                }
             });
         });
 
         //Cancel
-        $("#conditionformat-cancel").click(function() {
+        $("#cf-cancel").click(function() {
             window.history.back();
         });
         setDropdown();

--- a/examples/conditionformat2/js/config.js
+++ b/examples/conditionformat2/js/config.js
@@ -400,8 +400,10 @@ jQuery.noConflict();
                 'en': {
                     'text': {
                         "1": "Required fields for Text Format Conditions row " + row_num + " are empty.",
-                        "2": "Input \"#000000 ~ #FFFFFF\" for Font Color in Text Format Conditions row " + row_num + ".",
-                        "3": "Input \"#000000 ~ #FFFFFF\" for Background Color in Text Format Conditions row " + row_num + ".",
+                        "2": "Input \"#000000 ~ #FFFFFF\" for Font Color in Text Format Conditions row " +
+                                row_num + ".",
+                        "3": "Input \"#000000 ~ #FFFFFF\" for Background Color in Text Format Conditions row " +
+                                row_num + ".",
                         "4": "Text Format Conditions row " + row_num + " includes HTML Characters.",
                         "5": "Text Format Conditions row " + row_num + " includes Status(Process Management)." +
                                 " Please enable this app's process management feature to include it in the condition."
@@ -410,8 +412,10 @@ jQuery.noConflict();
                         "1": "Required fields for Date Format Conditions row " + row_num + " are empty.",
                         "2": "Input integers for Value of Date Format Conditions row " + row_num + ".",
                         "3": "Input integers for Value of Date Format Conditions row " + row_num + ".",
-                        "4": "Input \"#000000 ~ #FFFFFF\" for Font Color of Date Format Conditions row " + row_num + ".",
-                        "5": "Input \"#000000 ~ #FFFFFF\" for Background Color of Date Format Conditions row " + row_num + ".",
+                        "4": "Input \"#000000 ~ #FFFFFF\" for Font Color of Date Format Conditions row " +
+                                row_num + ".",
+                        "5": "Input \"#000000 ~ #FFFFFF\" for Background Color of Date Format Conditions row " +
+                                row_num + ".",
                         "6": "Date Format Conditions row " + row_num + " includes HTML Characters.",
                         "7": "Date Format Conditions row " + row_num + " includes Status(Process Management)." +
                                 " Please enable this app's process management feature to include it in the condition."

--- a/examples/conditionformat2/js/config.js
+++ b/examples/conditionformat2/js/config.js
@@ -6,313 +6,685 @@
  */
 
 jQuery.noConflict();
-
 (function($, PLUGIN_ID) {
     "use strict";
 
-    // 秘密鍵の設定
     var CONF = kintone.plugin.app.getConfig(PLUGIN_ID);
-    var MAX_LINE = 10;//行数指定
+    var TEXT_ROW_NUM = Number(CONF["text_row_number"]);
+    var DATE_ROW_NUM = Number(CONF["date_row_number"]);
 
-    $(function() {
-        // ツールチップ機能を適用
-        $(".conditionformat-plugin-tooltip").tooltip();
-    });
-
-    function escapeHtml(htmlstr) {
-        return htmlstr.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+    for (var t = 1; t < TEXT_ROW_NUM + 1; t++) {
+        CONF["text_row" + t] = JSON.parse(CONF["text_row" + t]);
+    }
+    for (var d = 1; d < DATE_ROW_NUM + 1; d++) {
+        CONF["date_row" + d] = JSON.parse(CONF["date_row" + d]);
     }
 
-    function setDefault() {
-        //既に値が設定されている場合はフィールドに値を設定する
-        if (CONF["body_text"]) {
-            var body_text = JSON.parse(CONF["body_text"]);
-            var body_date = JSON.parse(CONF["body_date"]);
-
-            for (var bm = 1; bm < MAX_LINE + 1; bm++) {
-                $("#conditionformat-cfield_text_" + bm).val(body_text["cfield_text_" + bm]["value"]);
-                $("#conditionformat-ctype_text_" + bm).val(body_text["ctype_text_" + bm]["value"]);
-                $("#conditionformat-cvalue_text_" + bm).val(body_text["cvalue_text_" + bm]["value"]);
-                $("#conditionformat-tfield_text_" + bm).val(body_text["tfield_text_" + bm]["value"]);
-                $("#conditionformat-tcolor_text_" + bm).val(body_text["tcolor_text_" + bm]["value"]);
-                $("#conditionformat-tbgcolor_text_" + bm).val(body_text["tbgcolor_text_" + bm]["value"]);
-                $("#conditionformat-tsize_text_" + bm).val(body_text["tsize_text_" + bm]["value"]);
-                $("#conditionformat-tcolor_text_" + bm)[0].
-                setAttribute("style", "color:" + body_text["tcolor_text_" + bm]["value"]);
-                $("#conditionformat-tbgcolor_text_" + bm)[0].
-                setAttribute("style", "color:" + body_text["tbgcolor_text_" + bm]["value"]);
-
-                $("#conditionformat-cfield_date_" + bm).val(body_date["cfield_date_" + bm]["value"]);
-                $("#conditionformat-ctype_date_" + bm).val(body_date["ctype_date_" + bm]["value"]);
-                $("#conditionformat-cvalue_date_" + bm).val(body_date["cvalue_date_" + bm]["value"]);
-                $("#conditionformat-tfield_date_" + bm).val(body_date["tfield_date_" + bm]["value"]);
-                $("#conditionformat-tcolor_date_" + bm).val(body_date["tcolor_date_" + bm]["value"]);
-                $("#conditionformat-tbgcolor_date_" + bm).val(body_date["tbgcolor_date_" + bm]["value"]);
-                $("#conditionformat-tsize_date_" + bm).val(body_date["tsize_date_" + bm]["value"]);
-                $("#conditionformat-tcolor_date_" + bm)[0].
-                setAttribute("style", "color:" + body_date["tcolor_date_" + bm]["value"]);
-                $("#conditionformat-tbgcolor_date_" + bm)[0].
-                setAttribute("style", "color:" + body_date["tbgcolor_date_" + bm]["value"]);
-            }
-        }
-    }
-
-    function setDropdown() {
-        // フォーム設計情報を取得し、選択ボックスに代入する
-        kintone.api(kintone.api.url("/k/v1/preview/form", true), "GET", {"app": kintone.app.getId()}, function(resp) {
-            var $option_status = $("<option>");
-            for (var st = 1; st < MAX_LINE + 1; st++) {
-                $option_status.attr("value", "status");
-                $option_status.text("ステータス");
-                $("#conditionformat-cfield_text_" + st).append($option_status.clone());
-                $("#conditionformat-tfield_text_" + st).append($option_status.clone());
-                $("#conditionformat-tfield_date_" + st).append($option_status.clone());
-            }
-            for (var i = 0; i < resp.properties.length; i++) {
-                var prop = resp.properties[i];
-                var $option = $("<option>");
-
-                switch (prop.type) {
-                    case "SINGLE_LINE_TEXT":
-                    case "NUMBER":
-                    case "CALC":
-                    case "RADIO_BUTTON":
-                    case "DROP_DOWN":
-                    case "RECORD_NUMBER":
-                    case "MULTI_LINE_TEXT":
-                    case "CHECK_BOX":
-                    case "MULTI_SELECT":
-
-                        for (var tm = 1; tm < MAX_LINE + 1; tm++) {
-                            $option.attr("value", escapeHtml(prop.code));
-                            $option.text(escapeHtml(prop.label));
-                            $("#conditionformat-cfield_text_" + tm).append($option.clone());
-                            $("#conditionformat-tfield_text_" + tm).append($option.clone());
-                            $("#conditionformat-tfield_date_" + tm).append($option.clone());
-                        }
-                        break;
-
-                    case "DATE":
-                    case "DATETIME":
-                    case "CREATED_TIME":
-                    case "UPDATED_TIME":
-                        for (var dm = 1; dm < MAX_LINE + 1; dm++) {
-                            $option.attr("value", escapeHtml(prop.code));
-                            $option.text(escapeHtml(prop.label));
-                            $("#conditionformat-tfield_text_" + dm).append($option.clone());
-                            $("#conditionformat-cfield_date_" + dm).append($option.clone());
-                            $("#conditionformat-tfield_date_" + dm).append($option.clone());
-                        }
-                        break;
-
-                    default :
-                        break;
-                }
-            }
-            setDefault();
-        });
-    }
-
-    function saveConfig(val) {
-        var config = [];
-        var body_text = {};
-        var body_date = {};
-        for (var si = 0; si < MAX_LINE; si++) {
-            var t = val[si].text;
-            var d = val[si].date;
-            var m = si + 1;
-
-            body_text["cfield_text_" + m] = {"value": t.fieldText};
-            body_text["ctype_text_" + m] = {"value": t.typeText};
-            body_text["cvalue_text_" + m] = {"value": t.valueText};
-            body_text["tfield_text_" + m] = {"value": t.targetFieldText};
-            body_text["tcolor_text_" + m] = {"value": t.targetColorText};
-            body_text["tbgcolor_text_" + m] = {"value": t.targetBackgroundColorText};
-            body_text["tsize_text_" + m] = {"value": t.targetSizeText};
-
-            body_date["cfield_date_" + m] = {"value": d.fieldDate};
-            body_date["ctype_date_" + m] = {"value": d.typeDate};
-            body_date["cvalue_date_" + m] = {"value": d.valueDate};
-            body_date["tfield_date_" + m] = {"value": d.targetFieldDate};
-            body_date["tcolor_date_" + m] = {"value": d.targetColorDate};
-            body_date["tbgcolor_date_" + m] = {"value": d.targetBackgroundColorDate};
-            body_date["tsize_date_" + m] = {"value": d.targetSizeDate};
-        }
-        config["body_text"] = JSON.stringify(body_text);
-        config["body_date"] = JSON.stringify(body_date);
-        config["line_number"] = String(MAX_LINE);
-
-        kintone.plugin.app.setConfig(config);
-    }
-
-    function checkValues(val) {
-        for (var ci = 0; ci < MAX_LINE; ci++) {
-            var t = val[ci].text;
-            var d = val[ci].date;
-
-            //文字条件書式必須入力項目チェック
-            if ((t.fieldText === "" || t.typeText === "" || t.targetFieldText === "") &&
-                !(t.fieldText === "" && t.typeText === "" && t.valueText === "" && t.targetFieldText === "")) {
-                alert("文字条件書式の" + (ci + 1) + "行目の必須入力項目を\n入力してください");
-                return false;
-            }
-
-            //日付条件書式必須入力項目チェック
-            if ((d.fieldDate === "" || d.typeDate === "" || d.targetFieldDate === "") &&
-                !(d.fieldDate === "" && d.typeDate === "" && d.targetFieldDate === "")) {
-                alert("日付条件書式の" + (ci + 1) + "行目の必須入力項目を\n入力してください");
-                return false;
-            }
-
-            //HTML特殊文字(&, <, >, ", ')が含まれるときエラー
-            if (t.valueText.match(/\&|<|\>|\"|\'/g) !== null || t.targetColorText.match(/\&|<|\>|\"|\'/g) !== null ||
-                t.targetBackgroundColorText.match(/\&|<|\>|\"|\'/g) !== null ||
-                d.valueDate.match(/\&|<|\>|\"|\'/g) !== null || d.targetColorDate.match(/\&|<|\>|\"|\'/g) !== null ||
-                d.targetBackgroundColorDate.match(/\&|<|\>|\"|\'/g) !== null) {
-                alert("条件値または色にHTML特殊文字(&, <, >, \", \')を\n入力することはできません");
-                return false;
-            }
-
-            //日付条件書式の条件値に数値とマイナス以外が入力されているときエラー
-            if (isNaN(d.valueDate)) {
-                alert("日付条件書式の" + (ci + 1) + "行目の条件値には\n半角数字もしくは - (マイナス)を入力してください");
-                return false;
-            }
-
-            //日付条件書式の条件値に.(小数点)を入力されているときエラー
-            if (d.valueDate.indexOf(".") > -1) {
-                alert("日付条件書式の" + (ci + 1) + "行目の条件値には\n整数を入力してください");
-                return false;
-            }
-
-            //文字条件書式の文字色のはじめの文字が#でなければエラー
-            if (t.targetColorText.slice(0, 1) !== "#") {
-                alert("文字条件書式の" + (ci + 1) + "行目の文字色には\n「#000000-#FFFFFF」を入力してください");
-                return false;
-            }
-
-            //日付条件書式の文字色のはじめの文字が#でなければエラー
-            if (d.targetColorDate.slice(0, 1) !== "#") {
-                alert("日付条件書式の" + (ci + 1) + "行目の文字色には\n「#000000-#FFFFFF」を入力してください");
-                return false;
-            }
-
-            //文字条件書式の文字色に#000000-#FFFFFF以外が入力されているときエラー
-            if (t.targetColorText.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
-                if (t.targetColorText !== "#000000") {
-                    alert("文字条件書式の" + (ci + 1) + "行目の文字色には\nカラーコード「#000000-#FFFFFF」を入力してください");
-                    return false;
-                }
-            }
-
-            //日付条件書式の文字色に#000000-#FFFFFF以外が入力されているときエラー
-            if (d.targetColorDate.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
-                if (d.targetColorDate !== "#000000") {
-                    alert("日付条件書式の" + (ci + 1) + "行目の文字色には\nカラーコード「#000000-#FFFFFF」を入力してください");
-                    return false;
-                }
-            }
-
-            //文字条件書式の背景色のはじめの文字が#でなければエラー
-            if (t.targetBackgroundColorText.slice(0, 1) !== "#") {
-                alert("文字条件書式の" + (ci + 1) + "行目の背景色には\n「#000000-#FFFFFF」を入力してください");
-                return false;
-            }
-
-            //日付条件書式の背景色のはじめの文字が#でなければエラー
-            if (d.targetBackgroundColorDate.slice(0, 1) !== "#") {
-                alert("日付条件書式の" + (ci + 1) + "行目の背景色には\n「#000000-#FFFFFF」を入力してください");
-                return false;
-            }
-
-            //文字条件書式の背景色に#000000-#FFFFFF以外が入力されているときエラー
-            if (t.targetBackgroundColorText.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
-                if (t.targetBackgroundColorText !== "#") {
-                    alert("文字条件書式の" + (ci + 1) + "行目の背景色には\nカラーコード「#000000-#FFFFFF」を入力してください");
-                    return false;
-                }
-            }
-
-            //日付条件書式の背景色に#000000-#FFFFFF以外が入力されているときエラー
-            if (d.targetBackgroundColorDate.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
-                if (d.targetBackgroundColorDate !== "#") {
-                    alert("日付条件書式の" + (ci + 1) + "行目の背景色には\nカラーコード「#000000-#FFFFFF」を入力してください");
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    //入力した値を取得。
-    function getValues(m) {
-        return {
-            text: {
-                fieldText: $("#conditionformat-cfield_text_" + m).val(),
-                typeText: $("#conditionformat-ctype_text_" + m).val(),
-                valueText: $("#conditionformat-cvalue_text_" + m).val(),
-                targetFieldText: $("#conditionformat-tfield_text_" + m).val(),
-                targetColorText: $("#conditionformat-tcolor_text_" + m).val(),
-                targetBackgroundColorText: $("#conditionformat-tbgcolor_text_" + m).val(),
-                targetSizeText: $("#conditionformat-tsize_text_" + m).val()
+    $(document).ready(function() {
+        var terms = {
+            'ja': {
+                'conditionformat_text_title': '文字条件書式',
+                'conditionformat_date_title': '日付条件書式',
+                'conditionformat_text_column1': '書式条件フィールド',
+                'conditionformat_text_column2': '条件式',
+                'conditionformat_text_column3': '条件値',
+                'conditionformat_text_column4': '書式変更フィールド',
+                'conditionformat_text_column5': '文字色',
+                'conditionformat_text_column6': '背景色',
+                'conditionformat_text_column7': '文字サイズ',
+                'conditionformat_text_column8': '文字装飾',
+                'conditionformat_text_column1_option1': 'ステータス(プロセス管理)',
+                'conditionformat_text_column2_option1': '条件値を含む',
+                'conditionformat_text_column2_option2': '条件値を含まない',
+                'conditionformat_text_column2_option3': '=(等しい)',
+                'conditionformat_text_column2_option4': '≠(等しくない)',
+                'conditionformat_text_column2_option5': '≦(以下)',
+                'conditionformat_text_column2_option6': '<(より小さい)',
+                'conditionformat_text_column2_option7': '≧(以上)',
+                'conditionformat_text_column2_option8': '>(より大きい)',
+                'conditionformat_text_column4_option1': 'ステータス(プロセス管理)',
+                'conditionformat_text_column7_option1': '変更なし',
+                'conditionformat_text_column7_option2': '小さい',
+                'conditionformat_text_column7_option3': 'やや小さい',
+                'conditionformat_text_column7_option4': 'やや大きい',
+                'conditionformat_text_column7_option5': '大きい',
+                'conditionformat_text_column8_option1': '変更なし',
+                'conditionformat_text_column8_option2': '太字',
+                'conditionformat_text_column8_option3': '下線',
+                'conditionformat_text_column8_option4': '打ち消し線',
+                'conditionformat_date_column1': '書式条件フィールド',
+                'conditionformat_date_column2': '条件式',
+                'conditionformat_date_column3': '条件値',
+                'conditionformat_date_column4': '書式変更フィールド',
+                'conditionformat_date_column5': '文字色',
+                'conditionformat_date_column6': '背景色',
+                'conditionformat_date_column7': '文字サイズ',
+                'conditionformat_date_column8': '文字装飾',
+                'conditionformat_date_column2_desc1': '今日から',
+                'conditionformat_date_column2_desc2': '日',
+                'conditionformat_date_column2_option1': '=(等しい)',
+                'conditionformat_date_column2_option2': '≠(等しくない)',
+                'conditionformat_date_column2_option3': '≦(以前)',
+                'conditionformat_date_column2_option4': '<(より前)',
+                'conditionformat_date_column2_option5': '≧(以後)',
+                'conditionformat_date_column2_option6': '>(より後)',
+                'conditionformat_date_column3_option1': '前',
+                'conditionformat_date_column3_option2': '後',
+                'conditionformat_date_column4_option1': 'ステータス(プロセス管理)',
+                'conditionformat_date_column7_option1': '変更なし',
+                'conditionformat_date_column7_option2': '小さい',
+                'conditionformat_date_column7_option3': 'やや小さい',
+                'conditionformat_date_column7_option4': 'やや大きい',
+                'conditionformat_date_column7_option5': '大きい',
+                'conditionformat_date_column8_option1': '変更なし',
+                'conditionformat_date_column8_option2': '太字',
+                'conditionformat_date_column8_option3': '下線',
+                'conditionformat_date_column8_option4': '打ち消し線',
+                'plugin_submit': '     保存   ',
+                'plugin_cancel': '  キャンセル   ',
+                'required_field': '必須項目が入力されていません。'
             },
-            date: {
-                fieldDate: $("#conditionformat-cfield_date_" + m).val(),
-                typeDate: $("#conditionformat-ctype_date_" + m).val(),
-                valueDate: $("#conditionformat-cvalue_date_" + m).val(),
-                targetFieldDate: $("#conditionformat-tfield_date_" + m).val(),
-                targetColorDate: $("#conditionformat-tcolor_date_" + m).val(),
-                targetBackgroundColorDate: $("#conditionformat-tbgcolor_date_" + m).val(),
-                targetSizeDate: $("#conditionformat-tsize_date_" + m).val()
+            'en': {
+                'conditionformat_text_title': 'Text Format Conditions',
+                'conditionformat_date_title': 'Date Format Conditions',
+                'conditionformat_text_column1': 'Field (condition)',
+                'conditionformat_text_column2': 'Condition',
+                'conditionformat_text_column3': 'Value',
+                'conditionformat_text_column4': 'Field (target)',
+                'conditionformat_text_column5': 'Font Color',
+                'conditionformat_text_column6': 'Background Color',
+                'conditionformat_text_column7': 'Font Size',
+                'conditionformat_text_column8': 'Style',
+                'conditionformat_text_column1_option1': 'Status(Process Management)',
+                'conditionformat_text_column2_option1': 'includes',
+                'conditionformat_text_column2_option2': 'doesn\'t include',
+                'conditionformat_text_column2_option3': '=',
+                'conditionformat_text_column2_option4': '≠',
+                'conditionformat_text_column2_option5': '≦',
+                'conditionformat_text_column2_option6': '<',
+                'conditionformat_text_column2_option7': '≧',
+                'conditionformat_text_column2_option8': '>',
+                'conditionformat_text_column4_option1': 'Status(Process Management)',
+                'conditionformat_text_column7_option1': 'Normal',
+                'conditionformat_text_column7_option2': 'Very Small',
+                'conditionformat_text_column7_option3': 'Small',
+                'conditionformat_text_column7_option4': 'Large',
+                'conditionformat_text_column7_option5': 'Very Large',
+                'conditionformat_text_column8_option1': 'Normal',
+                'conditionformat_text_column8_option2': 'Bold',
+                'conditionformat_text_column8_option3': 'Underline',
+                'conditionformat_text_column8_option4': 'Strikethrough',
+                'conditionformat_date_column1': 'Field (condition)',
+                'conditionformat_date_column2': 'Condition',
+                'conditionformat_date_column3': 'Value',
+                'conditionformat_date_column4': 'Field (target)',
+                'conditionformat_date_column5': 'Font Color',
+                'conditionformat_date_column6': 'Background Color',
+                'conditionformat_date_column7': 'Font Size',
+                'conditionformat_date_column8': 'Style',
+                'conditionformat_date_column2_desc1': '',
+                'conditionformat_date_column2_desc2': 'days',
+                'conditionformat_date_column2_option1': '=',
+                'conditionformat_date_column2_option2': '≠',
+                'conditionformat_date_column2_option3': '≦',
+                'conditionformat_date_column2_option4': '<',
+                'conditionformat_date_column2_option5': '≧',
+                'conditionformat_date_column2_option6': '>',
+                'conditionformat_date_column3_option1': 'before today',
+                'conditionformat_date_column3_option2': 'after today',
+                'conditionformat_date_column4_option1': 'Status(Process Management)',
+                'conditionformat_date_column7_option1': 'Normal',
+                'conditionformat_date_column7_option2': 'Very Small',
+                'conditionformat_date_column7_option3': 'Small',
+                'conditionformat_date_column7_option4': 'Large',
+                'conditionformat_date_column7_option5': 'Very Large',
+                'conditionformat_date_column8_option1': 'Normal',
+                'conditionformat_date_column8_option2': 'Bold',
+                'conditionformat_date_column8_option3': 'Underline',
+                'conditionformat_date_column8_option4': 'Strikethrough',
+                'plugin_submit': '     Save   ',
+                'plugin_cancel': '  Cancel   ',
+                'required_field': 'Required field is empty.'
+            },
+            'zh': {
+                'conditionformat_text_title': '文字条件格式',
+                'conditionformat_date_title': '日期条件格式',
+                'conditionformat_text_column1': '条件字段',
+                'conditionformat_text_column2': '条件公式',
+                'conditionformat_text_column3': '条件值',
+                'conditionformat_text_column4': '要更改格式的字段',
+                'conditionformat_text_column5': '字体颜色',
+                'conditionformat_text_column6': '背景色',
+                'conditionformat_text_column7': '文字大小',
+                'conditionformat_text_column8': '字体装饰',
+                'conditionformat_text_column1_option1': '状态(流程管理)',
+                'conditionformat_text_column2_option1': '包含条件值',
+                'conditionformat_text_column2_option2': '不包含条件值',
+                'conditionformat_text_column2_option3': '=(等于)',
+                'conditionformat_text_column2_option4': '≠(不等于)',
+                'conditionformat_text_column2_option5': '≦(小于或等于)',
+                'conditionformat_text_column2_option6': '<(小于)',
+                'conditionformat_text_column2_option7': '≧(大于或等于)',
+                'conditionformat_text_column2_option8': '>(大于)',
+                'conditionformat_text_column4_option1': '状态(流程管理)',
+                'conditionformat_text_column7_option1': '不更改',
+                'conditionformat_text_column7_option2': '小',
+                'conditionformat_text_column7_option3': '稍小',
+                'conditionformat_text_column7_option4': '稍大',
+                'conditionformat_text_column7_option5': '大',
+                'conditionformat_text_column8_option1': '不更改',
+                'conditionformat_text_column8_option2': '粗体',
+                'conditionformat_text_column8_option3': '下划线',
+                'conditionformat_text_column8_option4': '删除线',
+                'conditionformat_date_column1': '条件字段',
+                'conditionformat_date_column2': '条件公式',
+                'conditionformat_date_column3': '条件值',
+                'conditionformat_date_column4': '要更改格式的字段',
+                'conditionformat_date_column5': '字体颜色',
+                'conditionformat_date_column6': '背景色',
+                'conditionformat_date_column7': '字体大小',
+                'conditionformat_date_column8': '字体装饰',
+                'conditionformat_date_column2_desc1': '今日起',
+                'conditionformat_date_column2_desc2': '天',
+                'conditionformat_date_column2_option1': '=(等于)',
+                'conditionformat_date_column2_option2': '≠(不等于)',
+                'conditionformat_date_column2_option3': '≦(以前)',
+                'conditionformat_date_column2_option4': '<(早于)',
+                'conditionformat_date_column2_option5': '≧(以后)',
+                'conditionformat_date_column2_option6': '>(晚于)',
+                'conditionformat_date_column3_option1': '前',
+                'conditionformat_date_column3_option2': '后',
+                'conditionformat_date_column4_option1': '状态(流程管理)',
+                'conditionformat_date_column7_option1': '不更改',
+                'conditionformat_date_column7_option2': '小',
+                'conditionformat_date_column7_option3': '稍小',
+                'conditionformat_date_column7_option4': '稍大',
+                'conditionformat_date_column7_option5': '大',
+                'conditionformat_date_column8_option1': '不更改',
+                'conditionformat_date_column8_option2': '粗体',
+                'conditionformat_date_column8_option3': '下划线',
+                'conditionformat_date_column8_option4': '删除线',
+                'plugin_submit': '     保存   ',
+                'plugin_cancel': '  取消   ',
+                'required_field': '有必填项未填写。'
             }
         };
-    }
 
-    //文字色のカラーコードが変更された際に文字色変更。
-    $(".conditionformat-color").change(function() {
-        var $el = $(this).parents("tr");
-        $($el[0]).find(".conditionformat-color");
-        $($el[0]).find(".conditionformat-color")[0].setAttribute("style", "color:" + $(this).val());
-        return true;
-    });
+        // To switch the display by the login user's language (English display in the case of Chinese)
+        var lang = kintone.getLoginUser().language;
+        var i18n = (lang in terms) ? terms[lang] : terms['en'];
 
-    //背景色のカラーコードが変更された際に文字色変更。
-    $(".conditionformat-backgroundcolor").change(function() {
-        var $el = $(this).parents("tr");
-        $($el[0]).find(".conditionformat-backgroundcolor");
-        $($el[0]).find(".conditionformat-backgroundcolor")[0].setAttribute("style", "color:" + $(this).val());
-        return true;
-    });
+        var configHtml = $('#conditionformat-plugin').html();
+        var tmpl = $.templates(configHtml);
+        $('div#conditionformat-plugin').html(tmpl.render({'terms': i18n}));
 
-
-    //クリアボタン押下時に押下された行を初期値にする。
-    $(".conditionformat-clear-buttons").click(function() {
-        var $el = $(this).parents("tr");
-        $($el[0]).find("select").val("");
-        $($el[0]).find(".conditionformat-cvalue").val("");
-        $($el[0]).find(".conditionformat-cvalue-date").val("0");
-        $($el[0]).find(".conditionformat-color").val("#000000");
-        $($el[0]).find(".conditionformat-color")[0].setAttribute("style", "color:" + "#000000");
-        $($el[0]).find(".conditionformat-backgroundcolor").val("#");
-        $($el[0]).find(".conditionformat-backgroundcolor")[0].setAttribute("style", "color:" + "#");
-    });
-
-    //「保存する」ボタン押下時に入力情報を設定する
-    $("#conditionformat-submit").click(function() {
-        var vals = [];
-        for (var gm = 1; gm < MAX_LINE + 1; gm++) {
-            vals.push(getValues(gm));
+        function escapeHtml(htmlstr) {
+            return htmlstr.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
         }
-        if (checkValues(vals)) {
-            saveConfig(vals);
+
+        function checkRowNumber() {
+            if ($("#conditionformat-plugin-text-tbody > tr").length === 2) {
+                $("#conditionformat-plugin-text-tbody > tr .removeList").eq(1).hide();
+            } else {
+                $("#conditionformat-plugin-text-tbody > tr .removeList").eq(1).show();
+            }
+
+            if ($("#conditionformat-plugin-date-tbody > tr").length === 2) {
+                $("#conditionformat-plugin-date-tbody > tr .removeList").eq(1).hide();
+            } else {
+                $("#conditionformat-plugin-date-tbody > tr .removeList").eq(1).show();
+            }
         }
-    });
 
-    //「キャンセル」ボタン押下時の処理
-    $("#conditionformat-cancel").click(function() {
-        window.history.back();
-    });
+        function setDefault() {
+            if (TEXT_ROW_NUM > 0) {
+                for (var ti = 1; ti <= TEXT_ROW_NUM; ti++) {
+                    $("#conditionformat-plugin-text-tbody > tr").eq(0).clone(true).insertAfter(
+                        $("#conditionformat-plugin-text-tbody > tr").eq(ti - 1)
+                    );
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column1").
+                        val(CONF["text_row" + ti]['field']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column2").
+                        val(CONF["text_row" + ti]['type']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column3").
+                        val(CONF["text_row" + ti]['value']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column4").
+                        val(CONF["text_row" + ti]['targetfield']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column5").
+                        val(CONF["text_row" + ti]['targetcolor']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column6").
+                        val(CONF["text_row" + ti]['targetbackgroundcolor']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column7").
+                        val(CONF["text_row" + ti]['targetsize']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column8").
+                        val(CONF["text_row" + ti]['targetfont']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column5")[0].
+                        setAttribute("style", "color:" + CONF["text_row" + ti]['targetcolor']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column6")[0].
+                        setAttribute("style", "color:" + CONF["text_row" + ti]['targetbackgroundcolor']);
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column5").
+                        parent('div').find('i')[0].setAttribute(
+                            "style", "border-bottom-color:" + CONF["text_row" + ti]['targetcolor']
+                    );
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ti + ") .conditionformat-plugin-column6").
+                        parent('div').find('i')[0].setAttribute(
+                            "style", "border-bottom-color:" + CONF["text_row" + ti]['targetbackgroundcolor']
+                    );
+                }
+            } else {
+                // Insert Row
+                $("#conditionformat-plugin-text-tbody > tr").eq(0).clone(true).insertAfter(
+                    $("#conditionformat-plugin-text-tbody > tr")
+                ).eq(0);
+            }
 
-    setDropdown();
+            if (DATE_ROW_NUM > 0) {
+                for (var di = 1; di <= DATE_ROW_NUM; di++) {
+                    $("#conditionformat-plugin-date-tbody > tr").eq(0).clone(true).insertAfter(
+                        $("#conditionformat-plugin-date-tbody > tr").eq(di - 1)
+                    );
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column1").
+                        val(CONF["date_row" + di]['field']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column2").
+                        val(CONF["date_row" + di]['type']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column3").
+                        val(CONF["date_row" + di]['value']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column3-select2").
+                        val(CONF["date_row" + di]['type2']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column4").
+                        val(CONF["date_row" + di]['targetfield']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column5").
+                        val(CONF["date_row" + di]['targetcolor']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column6").
+                        val(CONF["date_row" + di]['targetbackgroundcolor']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column7").
+                        val(CONF["date_row" + di]['targetsize']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column8").
+                        val(CONF["date_row" + di]['targetfont']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column5")[0].
+                        setAttribute("style", "color:" + CONF["date_row" + di]['targetcolor']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column6")[0].
+                        setAttribute("style", "color:" + CONF["date_row" + di]['targetbackgroundcolor']);
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column5").
+                        parent('div').find('i')[0].setAttribute(
+                            "style", "border-bottom-color:" + CONF["date_row" + di]['targetcolor']
+                    );
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + di + ") .conditionformat-plugin-column6").
+                        parent('div').find('i')[0].setAttribute(
+                            "style", "border-bottom-color:" + CONF["date_row" + di]['targetbackgroundcolor']
+                    );
+                }
+            } else {
+                // Insert Row
+                $("#conditionformat-plugin-date-tbody > tr").eq(0).clone(true).insertAfter(
+                    $("#conditionformat-plugin-date-tbody > tr")
+                ).eq(0);
+            }
+            checkRowNumber();
+        }
+
+        function setDropdown() {
+            var param = {"app": kintone.app.getId()};
+            kintone.api(kintone.api.url("/k/v1/preview/app/form/fields", true), "GET", param, function(resp) {
+                for (var key in resp.properties) {
+                    if (!resp.properties.hasOwnProperty(key)) { continue; }
+                    var prop = resp.properties[key];
+                    var $option = $("<option>");
+
+                    switch (prop.type) {
+                        case "SINGLE_LINE_TEXT":
+                        case "NUMBER":
+                        case "CALC":
+                        case "RADIO_BUTTON":
+                        case "DROP_DOWN":
+                        case "RECORD_NUMBER":
+                        case "MULTI_LINE_TEXT":
+                        case "CHECK_BOX":
+                        case "MULTI_SELECT":
+                            $option.attr("value", escapeHtml(prop.code));
+                            $option.text(escapeHtml(prop.label));
+                            $("#conditionformat-plugin-text-tbody > tr:eq(0) .conditionformat-plugin-column1").
+                                append($option.clone());
+                            $("#conditionformat-plugin-text-tbody > tr:eq(0) .conditionformat-plugin-column4").
+                                append($option.clone());
+                            $("#conditionformat-plugin-date-tbody > tr:eq(0) .conditionformat-plugin-column4").
+                                append($option.clone());
+                            break;
+
+                        case "DATE":
+                        case "DATETIME":
+                        case "CREATED_TIME":
+                        case "UPDATED_TIME":
+                            $option.attr("value", escapeHtml(prop.code));
+                            $option.text(escapeHtml(prop.label));
+                            $("#conditionformat-plugin-text-tbody > tr:eq(0) .conditionformat-plugin-column1").
+                                append($option.clone());
+                            $("#conditionformat-plugin-date-tbody > tr:eq(0) .conditionformat-plugin-column4").
+                                append($option.clone());
+                            $("#conditionformat-plugin-date-tbody > tr:eq(0) .conditionformat-plugin-column1").
+                                append($option.clone());
+                            break;
+
+                        default :
+                            break;
+                    }
+                }
+                setDefault();
+            });
+        }
+
+        function showErrorMessages(type, error_num, row_num) {
+            var user_lang = kintone.getLoginUser().language;
+            var messages = {
+                'ja': {
+                    'text': {
+                        "1": "文字条件書式の" + row_num + "行目の必須入力項目を入力してください",
+                        "2": "文字条件書式の" + row_num + "行目の文字色には\nカラーコード「#000000-#FFFFFF」を入力してください",
+                        "3": "文字条件書式の" + row_num + "行目の背景色には\nカラーコード「#000000-#FFFFFF」を入力してください",
+                        "4": "文字条件書式の" + row_num + "行目の条件値または色に\n" +
+                                "HTML特殊文字(&, <, >, \", \')を入力することはできません",
+                        "5": "文字条件書式の" + row_num + "行目に「ステータス(プロセス管理)」を追加するには\n" +
+                                "プロセス管理の設定を有効にしてください"
+                    },
+                    'date': {
+                        "1": "日付条件書式の" + row_num + "行目の必須入力項目を入力してください",
+                        "2": "日付条件書式の" + row_num + "行目の条件値には\n半角数字を入力してください",
+                        "3": "日付条件書式の" + row_num + "行目の条件値には\n整数を入力してください",
+                        "4": "日付条件書式の" + row_num + "行目の文字色には\nカラーコード「#000000-#FFFFFF」を入力してください",
+                        "5": "日付条件書式の" + row_num + "行目の背景色には\nカラーコード「#000000-#FFFFFF」を入力してください",
+                        "6": "日付条件書式の" + row_num + "行目の条件値または色に\nHTML特殊文字(&, <, >, \", \')を入力することはできません",
+                        "7": "日付条件書式の" + row_num + "行目に「ステータス(プロセス管理)」を追加するには\nプロセス管理の設定を有効にしてください"
+                    }
+                },
+                'en': {
+                    'text': {
+                        "1": "Required fields for Text Format Conditions row " + row_num + " are empty.",
+                        "2": "Input \"#000000 ~ #FFFFFF\" for Font Color in Text Format Conditions row " + row_num + ".",
+                        "3": "Input \"#000000 ~ #FFFFFF\" for Background Color in Text Format Conditions row " + row_num + ".",
+                        "4": "Text Format Conditions row " + row_num + " includes HTML Characters.",
+                        "5": "Text Format Conditions row " + row_num + " includes Status(Process Management)." +
+                                " Please enable this app's process management feature to include it in the condition."
+                    },
+                    'date': {
+                        "1": "Required fields for Date Format Conditions row " + row_num + " are empty.",
+                        "2": "Input integers for Value of Date Format Conditions row " + row_num + ".",
+                        "3": "Input integers for Value of Date Format Conditions row " + row_num + ".",
+                        "4": "Input \"#000000 ~ #FFFFFF\" for Font Color of Date Format Conditions row " + row_num + ".",
+                        "5": "Input \"#000000 ~ #FFFFFF\" for Background Color of Date Format Conditions row " + row_num + ".",
+                        "6": "Date Format Conditions row " + row_num + " includes HTML Characters.",
+                        "7": "Date Format Conditions row " + row_num + " includes Status(Process Management)." +
+                                " Please enable this app's process management feature to include it in the condition."
+                    }
+                },
+                'zh': {
+                    'text': {
+                        "1": "文字条件格式的第" + row_num + "行有必填项未填写",
+                        "2": "文字条件格式的第" + row_num + "行的字体颜色框中\n请输入颜色代码[#000000-#FFFFFF]",
+                        "3": "文字条件格式的第" + row_num + "行的背景色框中\n请输入颜色代码[#000000-#FFFFFF]",
+                        "4": "文字条件格式的第" + row_num + "行的条件值或颜色不可输入\nHTML特殊符号(&, <, >, \", \')",
+                        "5": "文字条件格式的第" + row_num + "行要指定[状态(流程管理)]的话\n请先启用流程管理"
+                    },
+                    'date': {
+                        "1": "日期条件格式的第" + row_num + "行有必填项未填写",
+                        "2": "日期条件格式的第" + row_num + "行的条件值\n仅可输入半角数字",
+                        "3": "日期条件格式的第" + row_num + "行的条件值\n仅可输入整数",
+                        "4": "日期条件格式的第" + row_num + "行的字体颜色\n请输入颜色代码[#000000-#FFFFFF]",
+                        "5": "日期条件格式的第" + row_num + "行的背景色\n请输入颜色代码[#000000-#FFFFFF]",
+                        "6": "日期条件格式的第" + row_num + "行的条件值或颜色不可输入\nHTML特殊符号(&, <, >, \", \')",
+                        "7": "日期条件格式的第" + row_num + "行要指定[状态(流程管理)]的话\n请先启用流程管理"
+                    }
+                }
+            };
+            alert(messages[user_lang][type][error_num]);
+        }
+
+        function getValues(type, num) {
+            switch (type) {
+                case "text":
+                    return {
+                        "field": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column1").val(),
+                        "type": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column2").val(),
+                        "value": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column3").val(),
+                        "targetfield": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column4").val(),
+                        "targetcolor": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column5").val(),
+                        "targetbackgroundcolor": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column6").val(),
+                        "targetsize": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column7").val(),
+                        "targetfont": $("#conditionformat-plugin-text-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column8").val()
+                    };
+                case "date":
+                    return {
+                        "field": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column1").val(),
+                        "type": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column2").val(),
+                        "value": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column3").val(),
+                        "type2": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column3-select2").val(),
+                        "targetfield": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column4").val(),
+                        "targetcolor": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column5").val(),
+                        "targetbackgroundcolor": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column6").val(),
+                        "targetsize": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column7").val(),
+                        "targetfont": $("#conditionformat-plugin-date-tbody > tr:eq(" + num +
+                                ") .conditionformat-plugin-column8").val()
+                    };
+                default:
+                    return "";
+            }
+        }
+        function checkTextValues(config, pm_type) {
+            var text_row_num = $("#conditionformat-plugin-text-tbody > tr").length - 1;
+            for (var ct = 1; ct <= text_row_num; ct++) {
+                var text = getValues("text", ct);
+                if (text.field === "" && text.type === "" && text.targetfield === "") {
+                    $("#conditionformat-plugin-text-tbody > tr:eq(" + ct + ")").remove();
+                    text_row_num = text_row_num - 1;
+                    ct--;
+                    continue;
+                }
+
+                if ((text.field === "" || text.type === "" || text.targetfield === "") &&
+                    !(text.field === "" && text.type === "" && text.targetfield === "")) {
+                    showErrorMessages("text", "1", ct);
+                    return false;
+                }
+
+                if (text.targetcolor.slice(0, 1) !== "#") {
+                    showErrorMessages("text", "2", ct);
+                    return false;
+                }
+
+                if (text.targetcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
+                    if (text.targetcolor !== "#000000") {
+                        showErrorMessages("text", "2", ct);
+                        return false;
+                    }
+                }
+
+                if (text.targetbackgroundcolor.slice(0, 1) !== "#") {
+                    showErrorMessages("text", "3", ct);
+                    return false;
+                }
+
+                if (text.targetbackgroundcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
+                    if (text.targetbackgroundcolor !== "#") {
+                        showErrorMessages("text", "3", ct);
+                        return false;
+                    }
+                }
+                if (text.value.match(/\&|<|\>|\"|\'/g) !== null ||
+                    text.targetcolor.match(/\&|<|\>|\"|\'/g) !== null ||
+                    text.targetbackgroundcolor.match(/\&|<|\>|\"|\'/g) !== null) {
+                    showErrorMessages("text", "4", ct);
+                    return false;
+                }
+                if (!pm_type &&
+                    (text.field === "status_process_management" || text.targetfield === "status_process_management")) {
+                    showErrorMessages("text", "5", ct);
+                    return false;
+                }
+                config["text_row" + ct] = JSON.stringify(text);
+            }
+            config["text_row_number"] = String(text_row_num);
+            return config;
+        }
+
+        function checkDateValues(config, pm_type) {
+            var date_row_num = $("#conditionformat-plugin-date-tbody > tr").length - 1;
+            for (var cd = 1; cd <= date_row_num; cd++) {
+                var date = getValues("date", cd);
+                if (date.field === "" && date.type === "" && date.targetfield === "") {
+                    $("#conditionformat-plugin-date-tbody > tr:eq(" + cd + ")").remove();
+                    date_row_num = date_row_num - 1;
+                    cd--;
+                    continue;
+                }
+                if ((date.field === "" || date.type === "" || date.targetfield === "") &&
+                    !(date.field === "" && date.type === "" && date.targetfield === "")) {
+                    showErrorMessages("date", "1", cd);
+                    return false;
+                }
+                if (isNaN(date.value)) {
+                    showErrorMessages("date", "2", cd);
+                    return false;
+                }
+                if (date.value.indexOf(".") > -1) {
+                    showErrorMessages("date", "3", cd);
+                    return false;
+                }
+                if (date.targetcolor.slice(0, 1) !== "#") {
+                    showErrorMessages("date", "4", cd);
+                    return false;
+                }
+                if (date.targetcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
+                    if (date.targetcolor !== "#000000") {
+                        showErrorMessages("date", "4", cd);
+                        return false;
+                    }
+                }
+                if (date.targetbackgroundcolor.slice(0, 1) !== "#") {
+                    showErrorMessages("date", "5", cd);
+                    return false;
+                }
+                if (date.targetbackgroundcolor.slice(1, 7).match(/[0-9A-Fa-f]{6}/) === null) {
+                    if (date.targetbackgroundcolor !== "#") {
+                        showErrorMessages("date", "5", cd);
+                        return false;
+                    }
+                }
+                if (date.value.match(/\&|<|\>|\"|\'/g) !== null ||
+                    date.targetcolor.match(/\&|<|\>|\"|\'/g) !== null ||
+                    date.targetbackgroundcolor.match(/\&|<|\>|\"|\'/g) !== null) {
+                    showErrorMessages("date", "6", cd);
+                    return false;
+                }
+                if (!pm_type && date.targetfield === "status_process_management") {
+                    showErrorMessages("date", "7", cd);
+                    return false;
+                }
+                config["date_row" + cd] = JSON.stringify(getValues("date", cd));
+            }
+            config["date_row_number"] = String(date_row_num);
+            return config;
+        }
+
+        function checkValues(pm_type) {
+            var config = {};
+            config = checkTextValues(config, pm_type);
+            if (!config) { return; }
+
+            config = checkDateValues(config, pm_type);
+            if (!config) { return; }
+
+            //SaveConfig
+            kintone.plugin.app.setConfig(config);
+        }
+
+        //Change color
+        $(".conditionformat-plugin-column5").change(function() {
+            $(this)[0].setAttribute("style", "color:" + $(this).val());
+            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + $(this).val());
+            return true;
+        });
+
+        //Change backgroundcolor
+        $(".conditionformat-plugin-column6").change(function() {
+            $(this)[0].setAttribute("style", "background-color:" + $(this).val());
+            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + $(this).val());
+            return true;
+        });
+
+        //Change color
+        $(".conditionformat-plugin-column5-color").change(function() {
+            var color_code = $(this).parent('div').find('input[type="color"]').val();
+            var $el = $(this).parent('div').find('input[type="text"]');
+            $el.val(color_code);
+            $el[0].setAttribute("style", "color:" + color_code);
+            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + color_code);
+            return true;
+        });
+
+        //Change color
+        $(".conditionformat-plugin-column6-color").change(function() {
+            var color_code = $(this).parent('div').find('input[type="color"]').val();
+            var $el = $(this).parent('div').find('input[type="text"]');
+            $el.val(color_code);
+            $el[0].setAttribute("style", "background-color:" + color_code);
+            $(this).parent('div').find('i')[0].setAttribute("style", "border-bottom-color:" + color_code);
+            return true;
+        });
+
+        //Color picker
+        $(".color-paint-brush").click(function() {
+            $($(this).parents('td')[0]).find('input[type="color"]').click();
+        });
+
+        //Add Row
+        $("#conditionformat-plugin-text-tbody .addList").click(function() {
+            $("#conditionformat-plugin-text-tbody > tr").eq(0).clone(true).insertAfter(
+                $(this).parent().parent()
+            );
+            checkRowNumber();
+        });
+
+        $("#conditionformat-plugin-date-tbody .addList").click(function() {
+            $("#conditionformat-plugin-date-tbody > tr").eq(0).clone(true).insertAfter(
+                $(this).parent().parent()
+            );
+            checkRowNumber();
+        });
+
+        // Remove Row
+        $(".removeList").click(function() {
+            $(this).parent().parent().remove();
+            checkRowNumber();
+        });
+
+        //Save
+        $("#conditionformat-submit").click(function() {
+            var param2 = {"app": kintone.app.getId()};
+            kintone.api(kintone.api.url("/k/v1/preview/app/status", true), "GET", param2, function(resp) {
+                checkValues(resp.enable);
+            });
+        });
+
+        //Cancel
+        $("#conditionformat-cancel").click(function() {
+            window.history.back();
+        });
+        setDropdown();
+    });
 })(jQuery, kintone.$PLUGIN_ID);

--- a/examples/conditionformat2/js/config.js
+++ b/examples/conditionformat2/js/config.js
@@ -33,7 +33,7 @@ jQuery.noConflict();
                 'cf_text_column6': '背景色',
                 'cf_text_column7': '文字サイズ',
                 'cf_text_column8': '文字装飾',
-                'cf_text_column1_option1': 'ステータス(プロセス管理)',
+                'cf_status_option': 'ステータス(プロセス管理)',
                 'cf_text_column2_option1': '条件値を含む',
                 'cf_text_column2_option2': '条件値を含まない',
                 'cf_text_column2_option3': '=(等しい)',
@@ -42,7 +42,6 @@ jQuery.noConflict();
                 'cf_text_column2_option6': '<(より小さい)',
                 'cf_text_column2_option7': '≧(以上)',
                 'cf_text_column2_option8': '>(より大きい)',
-                'cf_text_column4_option1': 'ステータス(プロセス管理)',
                 'cf_text_column7_option1': '変更なし',
                 'cf_text_column7_option2': '小さい',
                 'cf_text_column7_option3': 'やや小さい',
@@ -70,7 +69,6 @@ jQuery.noConflict();
                 'cf_date_column2_option6': '>(より後)',
                 'cf_date_column3_option1': '前',
                 'cf_date_column3_option2': '後',
-                'cf_date_column4_option1': 'ステータス(プロセス管理)',
                 'cf_date_column7_option1': '変更なし',
                 'cf_date_column7_option2': '小さい',
                 'cf_date_column7_option3': 'やや小さい',
@@ -95,7 +93,7 @@ jQuery.noConflict();
                 'cf_text_column6': 'Background Color',
                 'cf_text_column7': 'Font Size',
                 'cf_text_column8': 'Style',
-                'cf_text_column1_option1': 'Status(Process Management)',
+                'cf_status_option': 'Status(Process Management)',
                 'cf_text_column2_option1': 'includes',
                 'cf_text_column2_option2': 'doesn\'t include',
                 'cf_text_column2_option3': '=',
@@ -104,7 +102,6 @@ jQuery.noConflict();
                 'cf_text_column2_option6': '<',
                 'cf_text_column2_option7': '≧',
                 'cf_text_column2_option8': '>',
-                'cf_text_column4_option1': 'Status(Process Management)',
                 'cf_text_column7_option1': 'Normal',
                 'cf_text_column7_option2': 'Very Small',
                 'cf_text_column7_option3': 'Small',
@@ -132,7 +129,6 @@ jQuery.noConflict();
                 'cf_date_column2_option6': '>',
                 'cf_date_column3_option1': 'before today',
                 'cf_date_column3_option2': 'after today',
-                'cf_date_column4_option1': 'Status(Process Management)',
                 'cf_date_column7_option1': 'Normal',
                 'cf_date_column7_option2': 'Very Small',
                 'cf_date_column7_option3': 'Small',
@@ -157,7 +153,7 @@ jQuery.noConflict();
                 'cf_text_column6': '背景色',
                 'cf_text_column7': '文字大小',
                 'cf_text_column8': '字体装饰',
-                'cf_text_column1_option1': '状态(流程管理)',
+                'cf_status_option': '状态(流程管理)',
                 'cf_text_column2_option1': '包含条件值',
                 'cf_text_column2_option2': '不包含条件值',
                 'cf_text_column2_option3': '=(等于)',
@@ -166,7 +162,6 @@ jQuery.noConflict();
                 'cf_text_column2_option6': '<(小于)',
                 'cf_text_column2_option7': '≧(大于或等于)',
                 'cf_text_column2_option8': '>(大于)',
-                'cf_text_column4_option1': '状态(流程管理)',
                 'cf_text_column7_option1': '不更改',
                 'cf_text_column7_option2': '小',
                 'cf_text_column7_option3': '稍小',
@@ -194,7 +189,6 @@ jQuery.noConflict();
                 'cf_date_column2_option6': '>(晚于)',
                 'cf_date_column3_option1': '前',
                 'cf_date_column3_option2': '后',
-                'cf_date_column4_option1': '状态(流程管理)',
                 'cf_date_column7_option1': '不更改',
                 'cf_date_column7_option2': '小',
                 'cf_date_column7_option3': '稍小',
@@ -375,6 +369,15 @@ jQuery.noConflict();
                             $("#cf-plugin-date-tbody > tr:eq(0) .cf-plugin-column1").append($option.clone());
                             break;
 
+                        case "STATUS":
+                            if (prop.enabled) {
+                                $option.attr("value", escapeHtml(prop.code));
+                                $option.text(terms[lang]["cf_status_option"]);
+                                $("#cf-plugin-text-tbody > tr:eq(0) .cf-plugin-column1").append($option.clone());
+                                $("#cf-plugin-text-tbody > tr:eq(0) .cf-plugin-column4").append($option.clone());
+                                $("#cf-plugin-date-tbody > tr:eq(0) .cf-plugin-column1").append($option.clone());
+                            }
+                            break;
                         default :
                             break;
                     }
@@ -447,8 +450,7 @@ jQuery.noConflict();
                         "1": "文字条件書式の" + row_num + "行目の必須入力項目を入力してください",
                         "2": "文字条件書式の" + row_num + "行目の文字色には\nカラーコード「#000000-#FFFFFF」を入力してください",
                         "3": "文字条件書式の" + row_num + "行目の背景色には\nカラーコード「#000000-#FFFFFF」を入力してください",
-                        "4": "文字条件書式の" + row_num + "行目の条件値または色に\n" + "HTML特殊文字(&, <, >, \", \')を入力することはできません",
-                        "5": "文字条件書式の" + row_num + "行目に「ステータス(プロセス管理)」を追加するには\n" + "プロセス管理の設定を有効にしてください"
+                        "4": "文字条件書式の" + row_num + "行目の条件値または色に\n" + "HTML特殊文字(&, <, >, \", \')を入力することはできません"
                     },
                     'date': {
                         "1": "日付条件書式の" + row_num + "行目の必須入力項目を入力してください",
@@ -456,8 +458,7 @@ jQuery.noConflict();
                         "3": "日付条件書式の" + row_num + "行目の条件値には\n整数を入力してください",
                         "4": "日付条件書式の" + row_num + "行目の文字色には\nカラーコード「#000000-#FFFFFF」を入力してください",
                         "5": "日付条件書式の" + row_num + "行目の背景色には\nカラーコード「#000000-#FFFFFF」を入力してください",
-                        "6": "日付条件書式の" + row_num + "行目の条件値または色に\nHTML特殊文字(&, <, >, \", \')を入力することはできません",
-                        "7": "日付条件書式の" + row_num + "行目に「ステータス(プロセス管理)」を追加するには\nプロセス管理の設定を有効にしてください"
+                        "6": "日付条件書式の" + row_num + "行目の条件値または色に\nHTML特殊文字(&, <, >, \", \')を入力することはできません"
                     }
                 },
                 'en': {
@@ -467,9 +468,7 @@ jQuery.noConflict();
                                 row_num + ".",
                         "3": "Input \"#000000 ~ #FFFFFF\" for Background Color in Text Format Conditions row " +
                                 row_num + ".",
-                        "4": "Text Format Conditions row " + row_num + " includes HTML Characters.",
-                        "5": "Text Format Conditions row " + row_num + " includes Status(Process Management)." +
-                                " Please enable this app's process management feature to include it in the condition."
+                        "4": "Text Format Conditions row " + row_num + " includes HTML Characters."
                     },
                     'date': {
                         "1": "Required fields for Date Format Conditions row " + row_num + " are empty.",
@@ -479,9 +478,7 @@ jQuery.noConflict();
                                 row_num + ".",
                         "5": "Input \"#000000 ~ #FFFFFF\" for Background Color of Date Format Conditions row " +
                                 row_num + ".",
-                        "6": "Date Format Conditions row " + row_num + " includes HTML Characters.",
-                        "7": "Date Format Conditions row " + row_num + " includes Status(Process Management)." +
-                                " Please enable this app's process management feature to include it in the condition."
+                        "6": "Date Format Conditions row " + row_num + " includes HTML Characters."
                     }
                 },
                 'zh': {
@@ -489,8 +486,7 @@ jQuery.noConflict();
                         "1": "文字条件格式的第" + row_num + "行有必填项未填写",
                         "2": "文字条件格式的第" + row_num + "行的字体颜色框中\n请输入颜色代码[#000000-#FFFFFF]",
                         "3": "文字条件格式的第" + row_num + "行的背景色框中\n请输入颜色代码[#000000-#FFFFFF]",
-                        "4": "文字条件格式的第" + row_num + "行的条件值或颜色不可输入\nHTML特殊符号(&, <, >, \", \')",
-                        "5": "文字条件格式的第" + row_num + "行要指定[状态(流程管理)]的话\n请先启用流程管理"
+                        "4": "文字条件格式的第" + row_num + "行的条件值或颜色不可输入\nHTML特殊符号(&, <, >, \", \')"
                     },
                     'date': {
                         "1": "日期条件格式的第" + row_num + "行有必填项未填写",
@@ -498,20 +494,18 @@ jQuery.noConflict();
                         "3": "日期条件格式的第" + row_num + "行的条件值\n仅可输入整数",
                         "4": "日期条件格式的第" + row_num + "行的字体颜色\n请输入颜色代码[#000000-#FFFFFF]",
                         "5": "日期条件格式的第" + row_num + "行的背景色\n请输入颜色代码[#000000-#FFFFFF]",
-                        "6": "日期条件格式的第" + row_num + "行的条件值或颜色不可输入\nHTML特殊符号(&, <, >, \", \')",
-                        "7": "日期条件格式的第" + row_num + "行要指定[状态(流程管理)]的话\n请先启用流程管理"
+                        "6": "日期条件格式的第" + row_num + "行的条件值或颜色不可输入\nHTML特殊符号(&, <, >, \", \')"
                     }
                 }
             };
             return error_messages[user_lang][type][error_num];
         }
 
-        function checkConfigTextValues(config, pm_type) {
+        function checkConfigTextValues(config) {
             var text_row_num = Number(config["text_row_number"]);
             for (var ct = 1; ct <= text_row_num; ct++) {
                 var text = JSON.parse(config["text_row" + ct]);
-                if ((text.field === "" || text.type === "" || text.targetfield === "") &&
-                    !(text.field === "" && text.type === "" && text.targetfield === "")) {
+                if (!text.field || !text.type || !text.targetfield) {
                     throw new Error(createErrorMessage("text", "1", ct));
                 }
 
@@ -539,19 +533,14 @@ jQuery.noConflict();
                     text.targetbgcolor.match(/\&|<|\>|\"|\'/g) !== null) {
                     throw new Error(createErrorMessage("text", "4", ct));
                 }
-                if (!pm_type &&
-                    (text.field === "status_process_management" || text.targetfield === "status_process_management")) {
-                    throw new Error(createErrorMessage("text", "5", ct));
-                }
             }
         }
 
-        function checkConfigDateValues(config, pm_type) {
+        function checkConfigDateValues(config) {
             var date_row_num = Number(config["date_row_number"]);
             for (var cd = 1; cd <= date_row_num; cd++) {
                 var date = JSON.parse(config["date_row" + cd]);
-                if ((date.field === "" || date.type === "" || date.targetfield === "") &&
-                    !(date.field === "" && date.type === "" && date.targetfield === "")) {
+                if (!date.field || !date.type || !date.targetfield) {
                     throw new Error(createErrorMessage("date", "1", cd));
                 }
                 if (isNaN(date.value)) {
@@ -581,15 +570,7 @@ jQuery.noConflict();
                     date.targetbgcolor.match(/\&|<|\>|\"|\'/g) !== null) {
                     throw new Error(createErrorMessage("date", "6", cd));
                 }
-                if (!pm_type && date.targetfield === "status_process_management") {
-                    throw new Error(createErrorMessage("date", "7", cd));
-                }
             }
-        }
-
-        function checkConfigValues(config, pm_type) {
-            checkConfigTextValues(config, pm_type);
-            checkConfigDateValues(config, pm_type);
         }
 
         function getValues(type, num) {
@@ -598,7 +579,7 @@ jQuery.noConflict();
                     return {
                         "field": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column1").val(),
                         "type": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column2").val(),
-                        "value": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column3").val(),
+                        "value": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column3").val().toString(),
                         "targetfield": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column4").val(),
                         "targetcolor": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column5").val(),
                         "targetbgcolor": $("#cf-plugin-text-tbody > tr:eq(" + num + ") .cf-plugin-column6").val(),
@@ -609,7 +590,7 @@ jQuery.noConflict();
                     return {
                         "field": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column1").val(),
                         "type": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column2").val(),
-                        "value": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column3").val(),
+                        "value": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column3").val().toString(),
                         "type2": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column3-select2").val(),
                         "targetfield": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column4").val(),
                         "targetcolor": $("#cf-plugin-date-tbody > tr:eq(" + num + ") .cf-plugin-column5").val(),
@@ -653,22 +634,16 @@ jQuery.noConflict();
             return config;
         }
 
-        function saveConfig(pm_type) {
-            var config = createConfig();
-            checkConfigValues(config, pm_type);
-            kintone.plugin.app.setConfig(config);
-        }
-
         //Save
         $("#cf-submit").click(function() {
-            var param2 = {"app": kintone.app.getId()};
-            kintone.api(kintone.api.url("/k/v1/preview/app/status", true), "GET", param2, function(resp) {
-                try {
-                    saveConfig(resp.enable);
-                } catch(error) {
-                    alert(error.message);
-                }
-            });
+            try {
+                var config = createConfig();
+                checkConfigTextValues(config);
+                checkConfigDateValues(config);
+                kintone.plugin.app.setConfig(config);
+            } catch(error) {
+                alert(error.message);
+            }
         });
 
         //Cancel

--- a/examples/conditionformat2/js/desktop.js
+++ b/examples/conditionformat2/js/desktop.js
@@ -198,6 +198,7 @@ jQuery.noConflict();
             text_obj = CONFIG["text_row" + ti];
             el_text = kintone.app.getFieldElements(text_obj.targetfield);
             if (!el_text) { continue; }
+
             for (var tn = 0; tn < el_text.length; tn++) {
                 field_obj = records[tn][text_obj.field];
                 if (field_obj.type === "CHECK_BOX" || field_obj.type === "MULTI_SELECT") {
@@ -235,6 +236,7 @@ jQuery.noConflict();
             text_obj = CONFIG["text_row" + ti];
             el_text = kintone.app.record.getFieldElement(text_obj.targetfield);
             if (!el_text) { continue; }
+
             field_obj = record[text_obj.field];
             if (field_obj.type === "CHECK_BOX" || field_obj.type === "MULTI_SELECT") {
                 for (var i = 0; i < field_obj.value.length; i++) {
@@ -253,6 +255,7 @@ jQuery.noConflict();
             date_obj = CONFIG["date_row" + di];
             el_date = kintone.app.record.getFieldElement(date_obj.targetfield);
             if (!el_date) { continue; }
+
             field_obj = record[date_obj.field];
             if (checkDateConditionFormat(field_obj.value, date_obj.value, date_obj.type, date_obj.type2)) {
                 changeFieldElement(el_date, date_obj, "detail");
@@ -260,43 +263,13 @@ jQuery.noConflict();
         }
     }
 
-    function changeStatusCode(record) {
-        var status_code = "status_process_management";
-        var fieldcode = Object.keys(record);
-
-        //Check status code
-        for (var n in fieldcode) {
-            if (!fieldcode.hasOwnProperty(n)) { continue; }
-            if (record[fieldcode[n]]["type"] === "STATUS") {
-                status_code = fieldcode[n];
-                break;
-            }
-        }
-
-        for (var ti = 1; ti <= TEXT_ROW_NUM; ti++) {
-            if (CONFIG["text_row" + ti].targetfield === "status_process_management") {
-                CONFIG["text_row" + ti].targetfield = status_code;
-            }
-            if (CONFIG["text_row" + ti].field === "status_process_management") {
-                CONFIG["text_row" + ti].field = status_code;
-            }
-        }
-        for (var di = 1; di <= DATE_ROW_NUM; di++) {
-            if (CONFIG["date_row" + di].targetfield === "status_process_management") {
-                CONFIG["date_row" + di].targetfield = status_code;
-            }
-        }
-    }
-
     kintone.events.on("app.record.index.show", function(event) {
         if (event.records.length <= 0) { return; }
-        changeStatusCode(event.records[0]);
         checkIndexConditionFormat(event.records);
         return;
     });
     kintone.events.on("app.record.detail.show", function(event) {
         if (!event.record) { return; }
-        changeStatusCode(event.record);
         checkDetailConditionFormat(event.record);
         return;
     });

--- a/examples/conditionformat2/js/desktop.js
+++ b/examples/conditionformat2/js/desktop.js
@@ -29,9 +29,12 @@ jQuery.noConflict();
             el.style.color = color;
         }
     }
-    function changeBackgroundColor(el, backgroundcolor) {
+    function changeBackgroundColor(el, backgroundcolor, type) {
         if (backgroundcolor) {
             el.style.backgroundColor = backgroundcolor;
+        }
+        if (type === "index") {
+            el.style.borderBottom = "solid 1px #F5F5F5";
         }
     }
     function changeFontSize(el, size) {
@@ -55,10 +58,10 @@ jQuery.noConflict();
         }
     }
 
-    function changeStyle(el, color, backgroundcolor, size, font) {
+    function changeStyle(el, color, backgroundcolor, size, font, type) {
         if (el) {
             changeColor(el, color);
-            changeBackgroundColor(el, backgroundcolor);
+            changeBackgroundColor(el, backgroundcolor, type);
             changeFontSize(el, size);
             changeFont(el, font);
         }
@@ -236,7 +239,8 @@ jQuery.noConflict();
                                 text_obj.targetcolor,
                                 text_obj.targetbackgroundcolor,
                                 text_obj.targetsize,
-                                text_obj.targetfont
+                                text_obj.targetfont,
+                                "index"
                             );
                             break;
                         }
@@ -247,7 +251,8 @@ jQuery.noConflict();
                         text_obj.targetcolor,
                         text_obj.targetbackgroundcolor,
                         text_obj.targetsize,
-                        text_obj.targetfont
+                        text_obj.targetfont,
+                        "index"
                     );
                 }
             }
@@ -268,7 +273,8 @@ jQuery.noConflict();
                         date_obj.targetcolor,
                         date_obj.targetbackgroundcolor,
                         date_obj.targetsize,
-                        date_obj.targetfont
+                        date_obj.targetfont,
+                        "index"
                     );
                 }
             }
@@ -308,7 +314,8 @@ jQuery.noConflict();
                             text_obj.targetcolor,
                             text_obj.targetbackgroundcolor,
                             text_obj.targetsize,
-                            text_obj.targetfont
+                            text_obj.targetfont,
+                            "detail"
                         );
                         break;
                     }
@@ -319,7 +326,8 @@ jQuery.noConflict();
                     text_obj.targetcolor,
                     text_obj.targetbackgroundcolor,
                     text_obj.targetsize,
-                    text_obj.targetfont
+                    text_obj.targetfont,
+                    "detail"
                 );
             }
         }
@@ -336,7 +344,8 @@ jQuery.noConflict();
                     date_obj.targetcolor,
                     date_obj.targetbackgroundcolor,
                     date_obj.targetsize,
-                    date_obj.targetfont
+                    date_obj.targetfont,
+                    "detail"
                 );
             }
         }

--- a/examples/conditionformat2/manifest.json
+++ b/examples/conditionformat2/manifest.json
@@ -1,39 +1,43 @@
 {
-	"manifest_version": 1,
-	"version": 2,
-	"type": "APP",
-	"name": {
-		"ja": "新条件書式プラグイン",
-		"en": "new conditional format plug-in",
-		"zh": "新条件格式插件"
-	},
-	"description": {
-		"ja": "新デザインに対応した条件により表示するアイテムの色、背景色等を変更するプラグインです。",
-		"en": "It is plug-in which changes the color etc. of the item displayed according to conditions. ",
-		"zh": "是變更根據條件表示的條款的顏色等的插件。"
-	},
-	"icon": "image/icon.png",
-	"desktop": {
-		"js": [
-			"https://js.cybozu.com/momentjs/2.10.6/moment.min.js",
-			"https://js.cybozu.com/jquery/2.1.4/jquery.min.js",
-			"js/desktop.js"
-		],
-		"css": [
-		]
-	},
-	"config": {
-		"html": "html/config.html",
-		"js": [
-			"https://js.cybozu.com/jquery/2.1.4/jquery.min.js",
-			"https://js.cybozu.com/jqueryui/1.11.4/jquery-ui.min.js",
-			"js/config.js"
-		],
-		"css": [
-			"css/51-us-default.css",
-			"https://js.cybozu.com/jqueryui/1.11.4/themes/smoothness/jquery-ui.css",
-			"https://js.cybozu.com/font-awesome/v4.4.0/css/font-awesome.min.css",
-			"css/config.css"
-		]
-	}
+    "manifest_version": 1,
+    "version": 3,
+    "type": "APP",
+    "name": {
+        "ja": "新条件書式プラグイン",
+        "en": "New conditional format plug-in",
+        "zh": "新条件格式插件"
+    },
+    "description": {
+        "ja": "新デザインに対応した条件により表示するアイテムの色、背景色等を変更するプラグインです。",
+        "en": "It is plug-in which changes the color etc. of the item displayed according to conditions. ",
+        "zh": "是變更根據條件表示的條款的顏色等的插件。"
+    },
+    "icon": "image/icon.png",
+    "homepage_url": {
+        "ja": "https://cybozudev.zendesk.com/hc/ja/articles/208236353",
+        "en": "https://cybozudev.zendesk.com/hc/ja/articles/208236353",
+        "zh": "https://cybozudev.kf5.com/hc/kb/article/1011206/"
+    },
+    "desktop": {
+        "js": [
+            "https://js.cybozu.com/momentjs/2.10.6/moment.min.js",
+            "https://js.cybozu.com/jquery/2.1.4/jquery.min.js",
+            "js/desktop.js"
+        ],
+        "css": [
+        ]
+    },
+    "config": {
+        "html": "html/config.html",
+        "js": [
+            "https://js.cybozu.com/jquery/2.1.4/jquery.min.js",
+            "https://js.cybozu.com/jsrender/0.9.83/jsrender.min.js",
+            "js/config.js"
+        ],
+        "css": [
+            "https://js.cybozu.com/font-awesome/v4.7.0/css/font-awesome.min.css",
+            "css/51-current-default.css",
+            "css/config.css"
+        ]
+    }
 }


### PR DESCRIPTION
下記の処理を追加

- 設定項目の可変行対応
- 設定項目のローカライズ対応（英語、中文）
- 設定項目のテーブルの見た目をサブテーブルに変更
- 設定に太字、打消し線、下線を追加
- カラーピッカー対応(Firefox, Chromeで利用可)
- 日付条件書式の条件値の設定方法変更
- 設定画面でのプロセス管理の「ステータス」項目の設定値の名称を「ステータス(プロセス管理)」に変更
- プロセス管理が有効でない場合、「ステータス(プロセス管理)」項目を選択できない処理に変更
- 不要なライブラリの削除
- font-awesomeの追加
- CSSファイルを51-current-default.cssに差し替え
- 一覧画面で背景色変更時にborderを追加
- その他ロジック変更等軽微な修正