### PR TITLE
css(kintoneplugin-title)のコメントを修正

### DIFF
--- a/stylesheet/51-current-default.css
+++ b/stylesheet/51-current-default.css
@@ -59,10 +59,10 @@
   font-weight: bold;
 }
 
-/* 設定項目の見出し */
+/* 設定項目名 */
 /* 項目 */
 /*
-<div class="kintoneplugin-title">設定項目の見出し</div>
+<div class="kintoneplugin-title">設定項目名</div>
 */
 .kintoneplugin-title {
   margin-bottom: 8px;


### PR DESCRIPTION
kintoneplugin-titleのコメント（日本語名部分）を修正しました。
「設定項目の見出し」→「設定項目名」