### PR TITLE
プラグイン保守対応

### DIFF
--- a/examples/appIndex/css/51-modern-default.css
+++ b/examples/appIndex/css/51-modern-default.css
@@ -59,10 +59,10 @@
   font-weight: bold;
 }
 
-/* 設定項目の見出し */
+/* 設定項目名 */
 /* 項目 */
 /*
-<div class="kintoneplugin-label">設定項目の見出し</div>
+<div class="kintoneplugin-title">設定項目名</div>
 */
 .kintoneplugin-title {
   margin-bottom: 8px;
@@ -538,4 +538,118 @@
   background-color: #c8d6dd;
   box-shadow: none;
   cursor: pointer;
+}
+
+
+/* Table */
+/*
+<table class="kintoneplugin-table">
+  <thead>
+    <tr>
+      <th class="kintoneplugin-table-th"><span class="title">Title1</span></th>
+      <th class="kintoneplugin-table-th-blankspace"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <div class="kintoneplugin-table-td-control">
+          <div class="kintoneplugin-table-td-control-value">
+            <div class="kintoneplugin-input-outer">
+              <input class="kintoneplugin-input-text" type="text">
+            </div>
+          </div>
+        </div>
+      </td>
+      <td class="kintoneplugin-table-td-operation">
+        <button type="button" class="kintoneplugin-button-add-row-image" title="Add row"></button>
+        <button type="button" class="kintoneplugin-button-remove-row-image" title="Delete this row"></button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+*/
+.kintoneplugin-table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  margin-left: 18px;
+  margin-bottom: 16px;
+}
+
+.kintoneplugin-table-th {
+  border-color: #3498db;
+  height: 40px;
+  color: #fff;
+  box-sizing: border-box;
+  text-align: left;
+  font-weight: 400;
+  font-size: 12px;
+  white-space: nowrap;
+  border-width: 2px;
+  background-color: #3498db;
+}
+
+.kintoneplugin-table-th .title {
+  display: inline-block;
+  padding: 4px 8px;
+  box-sizing: border-box;
+  min-width: 204px;
+}
+
+.kintoneplugin-table-th-blankspace {
+  background-color: transparent;
+}
+
+.kintoneplugin-table td {
+  border-color: #e3e7e8;
+  border-style: solid;
+  border-width: 0 1px 1px 0;
+  vertical-align: top;
+  padding: 4px 0;
+}
+
+.kintoneplugin-table td:first-child {
+    border-left-width: 1px;
+}
+
+.kintoneplugin-table td.kintoneplugin-table-td-operation {
+  border-right: 0;
+  border-bottom: 0;
+}
+
+.kintoneplugin-table-td-control {
+  padding: 0 8px;
+}
+
+.kintoneplugin-table-td-control-value {
+  overflow: hidden;
+  padding: 4px 0;
+  min-height: 21px;
+  color: #333;
+  background-color: transparent;
+}
+
+.kintoneplugin-table-td-operation .kintoneplugin-button-add-row-image, .kintoneplugin-table-td-operation .kintoneplugin-button-remove-row-image {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+}
+
+.kintoneplugin-table-td-operation .kintoneplugin-button-add-row-image {
+  margin-left: 12px;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAABG0lEQVQ4ja2UMWrDUAyG31TIAUIO0cVbCMToHa0nyF4HqbtPkBPkAqEe/KQ4bclkCB06FDqoQ7Cb5j2/l1L/oMFY/pB+SzImoZzc1BZ1lpObpnKDsihLICkBubIohy4AuQKS0qIsk5DFajsBdAQo+0vIdQBJA+hosdpOgqD7h+c7S7yJQbwg3gSBgPz4J1DfuqNrkyHR2vswTPY5Ofip6mzqQDIfVVUTHpaXLVb/giFXxhhj5uvdLJGYhFmUw3y9mxlb1Jn/kj81Ikvy4X1T1FmwMkB+A+QWkFsgOamq9s/ILRC/Bisb1bPR/2ZszoDkBZC/bp6zc6uORtmAbslH281fV4OkSXjUAPLTIMjb1cg98zy6Vd2l7ecoom+t8LKwzLF7UgAAAABJRU5ErkJggg==) center center no-repeat;
+  border: 1px solid transparent;
+}
+.kintoneplugin-table-td-operation .kintoneplugin-button-add-row-image:hover {
+  cursor: pointer;
+}
+.kintoneplugin-table-td-operation .kintoneplugin-button-remove-row-image {
+  margin-left: 4px;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAABPUlEQVQ4ja2UvW6DMBDHUTMkK0vyQJXoxoaUB2nWxEorMcNgD/gOWbIii7GSJx6Bmdegq1lKF6CUAqYSJ/2HE8dP5/tyHIvFcbynlLpxHO9tsZPGGDsCgI+IrwBAOrW+zxg7WiFBEOwAwEPE6xAyVpqmNwDwgiDYTYIIIU+c8/MSZCzO+XkSyDl//g9oIO8XKEmSk+1pc0LEa5Ikpx4GAP5csFIqVEqFFqjfw8ZdGyrLsjDLMhvs0hX+sBS4EkYIIQeHUuqOP5Rl+WGMqYwxVV3Xn03TfHW+MaYqiuIx/odS6k5mJqV811pHWusoz3OW5znrfK11JKV8m8xs05rZurkS9tPNpTkTQtyFEPfVc9Zm522yAd2Sb7abw6vRXoVZSJqmN0R8mQWNdxUm7hkAXADA/1OjtdZd2n6OFuwblG9sdxWO0ggAAAAASUVORK5CYII=) center center no-repeat;
+  border: 1px solid transparent;
+}
+
+.kintoneplugin-table-td-operation .kintoneplugin-button-remove-row-image:hover {
+  cursor: pointer;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAACi0lEQVQ4jZ2UT0hUQRzHp0uHDtFVk0QqTGtdddXVN/Pe7ubuuu3Me7sY2s1jRZcOQX+kQC+dkrr15xAIElhIEBSZloKHPHTMIlHS9r2ZNdvUNK1Evh3S1WVdNX/wuf1+H+bHzHcIyVET4ZoiJViLjLKrjmBtUtBrdpSetwVzE0L25JrLKBlkh6RgHZJTWwmGLDidk5x2qYhWvaXIidKQ5Gx0U8kGkoJBCfpTcXZpU5HNNS45+7WdaKNwJmZgJORtz1wtqhVKQSd3Klpj2tSRMg28NtzhdZlgHf8rUoJBCoZZy8B4Q+27+578fWQiXFMkOfu6W5kSFL8bA3hQUWwRJVhLdqMOZW7Daq/NKVaa6tFdV9ZJJKetGRLLgBOogENL4bAc0FI4QQ+UZUByipSpIylYP3EEa0vLIrWQfjcWeh5hOTGBP2OfshkfxfLkZ8zduw1HOwZlGZgSOuZjvgGiOL2Rlp2qg6yvxNzdDiwNvsJi3/Ns+l9gaaAX329eh2OcgDR1TJs6Zi3jDVFcuyA3rhnzwa4tRsKVj4S7IJuyAiRcB+Hox6HifticYrHRj7eBqh6SiHjLFGcLGRdgGVAxP1TMlwP/vx7BYEcpcCaEO+6j59Zi1L2bp5HgFPNxH2Ysw24tKcwjhBDyJaJVJ9OZ2xkOp1CCAc1BdFaXXMyI1CTXrkybOr6ZOuQOTpRcFY2E6540EbI3K+zvQ972pGBIWQaSpg6bU0i+/todTmFzioW4D2iux8eG2p6n5eUHcn5Dw4Gq6FhEG0qZOlZOBzAb8yG5GuqlRj/QHMSU0Me7akoub/mfpYXeI/uHfJXmM8318EPY2/sj7h+ctfS+4ZOex7dch8++9JTkbTb3FyHXv8RgEtykAAAAAElFTkSuQmCC) center center no-repeat;
 }

--- a/examples/appIndex/js/config.js
+++ b/examples/appIndex/js/config.js
@@ -1,66 +1,66 @@
 /* Author : cstap inc. Takuji Takei */
 jQuery.noConflict();
 (function($, PLUGIN_ID) {
-    "use strict";
+    'use strict';
 
     // プラグインIDの設定
     var conf = kintone.plugin.app.getConfig(PLUGIN_ID);
     // 言語
     var language = kintone.getLoginUser().language;
-    if (language === "zh") {
-        $("span#container_label").eq(0).text("请选择文件夹的图标");
-        $("span#container_label").eq(1).text("请选择软件连接的图标");
-        $(".kintoneplugin-button-dialog-ok").text("保存");
-        $(".kintoneplugin-button-dialog-cancel").text("取消");
-        $("[for=f_folder]").text("默认设置");
-        $("[for=a_file]").text("默认设置");
-    } else if (language === "en") {
-        $("span#container_label").eq(0).text("Please select folder icon");
-        $("span#container_label").eq(1).text("Please select app link icon");
-        $(".kintoneplugin-button-dialog-ok").text("save");
-        $(".kintoneplugin-button-dialog-cancel").text("cancel");
-        $("[for=f_folder]").text("default");
-        $("[for=a_file]").text("default");
+    if (language === 'zh') {
+        $('span#container_label').eq(0).text('请选择文件夹的图标');
+        $('span#container_label').eq(1).text('请选择软件连接的图标');
+        $('.kintoneplugin-button-dialog-ok').text('保存');
+        $('.kintoneplugin-button-dialog-cancel').text('取消');
+        $('[for=f_folder]').text('默认设置');
+        $('[for=a_file]').text('默认设置');
+    } else if (language === 'en') {
+        $('span#container_label').eq(0).text('Please select folder icon');
+        $('span#container_label').eq(1).text('Please select app link icon');
+        $('.kintoneplugin-button-dialog-ok').text('save');
+        $('.kintoneplugin-button-dialog-cancel').text('cancel');
+        $('[for=f_folder]').text('default');
+        $('[for=a_file]').text('default');
     }
 
-    //既に値が設定されている場合はフィールドに値を設定する
+    // 既に値が設定されている場合はフィールドに値を設定する
     if (typeof (conf['folderIcon']) !== 'undefined') {
         $('#f_' + conf['folderIcon']).prop('checked', true);
         $('#a_' + conf['appIcon']).prop('checked', true);
     } else {
         // 初回プラグイン設定時のみ必要なフォームを自動追加する
         kintone.api('/k/v1/preview/app/form/fields', 'POST', {
-            "app": kintone.app.getId(),
-            "properties": {
-                "folderName": {
-                    "code": "folderName",
-                    "label": "フォルダ名",
-                    "type": "SINGLE_LINE_TEXT"
+            'app': kintone.app.getId(),
+            'properties': {
+                'folderName': {
+                    'code': 'folderName',
+                    'label': 'フォルダ名',
+                    'type': 'SINGLE_LINE_TEXT'
                 },
-                "appName": {
-                    "code": "appName",
-                    "label": "アプリ名",
-                    "type": "SINGLE_LINE_TEXT"
+                'appName': {
+                    'code': 'appName',
+                    'label': 'アプリ名',
+                    'type': 'SINGLE_LINE_TEXT'
                 },
-                "appSort": {
-                    "code": "appSort",
-                    "label": "アプリ順",
-                    "type": "NUMBER"
+                'appSort': {
+                    'code': 'appSort',
+                    'label': 'アプリ順',
+                    'type': 'NUMBER'
                 },
-                "parentFolderID": {
-                    "code": "parentFolderID",
-                    "label": "親フォルダID",
-                    "type": "SINGLE_LINE_TEXT"
+                'parentFolderID': {
+                    'code': 'parentFolderID',
+                    'label': '親フォルダID',
+                    'type': 'SINGLE_LINE_TEXT'
                 },
-                "appID": {
-                    "code": "appID",
-                    "label": "アプリID",
-                    "type": "SINGLE_LINE_TEXT"
+                'appID': {
+                    'code': 'appID',
+                    'label': 'アプリID',
+                    'type': 'SINGLE_LINE_TEXT'
                 },
-                "selfFolderID": {
-                    "code": "selfFolderID",
-                    "label": "自フォルダID",
-                    "type": "SINGLE_LINE_TEXT"
+                'selfFolderID': {
+                    'code': 'selfFolderID',
+                    'label': '自フォルダID',
+                    'type': 'SINGLE_LINE_TEXT'
                 }
             }
         }, function(resp) {
@@ -68,29 +68,29 @@ jQuery.noConflict();
         });
     }
 
-    //「保存する」ボタン押下時に入力情報を設定する
+    // 「保存する」ボタン押下時に入力情報を設定する
     $('#submit').click(function() {
         var config = [];
 
-        config['folderIcon'] = $("[name=folder]:checked").val();
-        config['appIcon'] = $("[name=app]:checked").val();
+        config['folderIcon'] = $('[name=folder]:checked').val();
+        config['appIcon'] = $('[name=app]:checked').val();
 
         if (config['folderIcon'] === config['appIcon']) {
-            if (language === "zh") {
-                alert("请选择别的图标");
-            } else if (language === "en") {
-                alert("Please select other icon");
+            if (language === 'zh') {
+                alert('请选择别的图标');
+            } else if (language === 'en') {
+                alert('Please select other icon');
             } else {
-                alert("フォルダとアプリは異なるアイコンにしてください。");
+                alert('フォルダとアプリは異なるアイコンにしてください。');
             }
             return;
         }
 
         // カスタマイズビューを追加
         var VIEW_NAME = 'アプリ一覧';
-        if (language === "zh") {
+        if (language === 'zh') {
             VIEW_NAME = '软件连接一览';
-        } else if (language === "en") {
+        } else if (language === 'en') {
             VIEW_NAME = 'app index';
         }
         kintone.api(kintone.api.url('/k/v1/preview/app/views', true), 'GET', {
@@ -117,29 +117,29 @@ jQuery.noConflict();
                         req.views[key].index = Number(req.views[key].index) + 1;
                     }
                 }
-                
-                var newFolderButton = " 新規フォルダ作成";
-                var newDefaultButton = " 初期状態に戻す";
-                if (language === "zh") {
-                    newFolderButton = " 作成新规文件夹";
-                    newDefaultButton = " 回复初期状态";
-                } else if (language === "en") {
-                    newFolderButton = " Create new folder";
-                    newDefaultButton = " Reset";
+
+                var newFolderButton = ' 新規フォルダ作成';
+                var newDefaultButton = ' 初期状態に戻す';
+                if (language === 'zh') {
+                    newFolderButton = ' 作成新规文件夹';
+                    newDefaultButton = ' 回复初期状态';
+                } else if (language === 'en') {
+                    newFolderButton = ' Create new folder';
+                    newDefaultButton = ' Reset';
                 }
 
                 req.views[VIEW_NAME] = {
-                    "type": "CUSTOM",
-                    "name": VIEW_NAME,
-                    "html": '<div class="row">' +
+                    'type': 'CUSTOM',
+                    'name': VIEW_NAME,
+                    'html': '<div class="row">' +
                         '<button type="button" id="folderCreate" class="btn btn-success btn-sm">' +
                         '<i class="glyphicon glyphicon-plus"></i>' + newFolderButton + '</button>' +
                         '<button type="button" id="returnDefault" class="btn btn-danger btn-sm" style="float:right;">' +
                         '<i class="glyphicon glyphicon-fast-backward"></i>' + newDefaultButton + '</button>' +
                         '</div><div id="tree"></div>',
-                    "filterCond": "",
-                    "pager": true,
-                    "index": 0
+                    'filterCond': '',
+                    'pager': true,
+                    'index': 0
                 };
 
                 kintone.api(kintone.api.url('/k/v1/preview/app/views', true), 'PUT', req).then(function(putResp) {
@@ -147,24 +147,24 @@ jQuery.noConflict();
                     var viewId = putResp.views[VIEW_NAME].id;
                     config['viewId'] = viewId;
                     // 言語を保存
-                    if (language === "ja") {
-                        config['lang'] = "ja";
-                    } else if (language === "zh") {
-                        config['lang'] = "zh";
+                    if (language === 'ja') {
+                        config['lang'] = 'ja';
+                    } else if (language === 'zh') {
+                        config['lang'] = 'zh';
                     } else {
-                        config['lang'] = "en";
+                        config['lang'] = 'en';
                     }
                     kintone.plugin.app.setConfig(config);
                 });
 
             } else {
                 // 言語を保存
-                if (language === "ja") {
-                    config['lang'] = "ja";
-                } else if (language === "zh") {
-                    config['lang'] = "zh";
+                if (language === 'ja') {
+                    config['lang'] = 'ja';
+                } else if (language === 'zh') {
+                    config['lang'] = 'zh';
                 } else {
-                    config['lang'] = "en";
+                    config['lang'] = 'en';
                 }
                 config['viewId'] = conf['viewId'];
                 kintone.plugin.app.setConfig(config);
@@ -173,10 +173,9 @@ jQuery.noConflict();
         });
     });
 
-    //「キャンセル」ボタン押下時の処理
+    // 「キャンセル」ボタン押下時の処理
     $('#cancel').click(function() {
         history.back();
     });
-
 
 })(jQuery, kintone.$PLUGIN_ID);

--- a/examples/appIndex/js/customize.js
+++ b/examples/appIndex/js/customize.js
@@ -1,28 +1,28 @@
 /* Author : cstap inc. Takuji Takei */
 jQuery.noConflict();
 (function($, PLUGIN_ID) {
-    "use strict";
+    'use strict';
     var config = kintone.plugin.app.getConfig(PLUGIN_ID);
     // 各言語対応
-    var recordNumber = "レコード番号";
-    var creator = "作成者";
-    var createTime = "作成日時";
-    var updator = "更新者";
-    var updateTime = "更新日時";
-    if (config.lang === "zh") {
-        recordNumber = "记录编号";
-        creator = "创建人";
-        createTime = "创建时间";
-        updator = "更新人";
-        updateTime = "更新时间";
-    } else if (config.lang === "en") {
-        recordNumber = "Record_number";
-        creator = "Created_by";
-        createTime = "Created_datetime";
-        updator = "Updated_by";
-        updateTime = "Updated_datetime";
+    var recordNumber = 'レコード番号';
+    var creator = '作成者';
+    var createTime = '作成日時';
+    var updator = '更新者';
+    var updateTime = '更新日時';
+    if (config.lang === 'zh') {
+        recordNumber = '记录编号';
+        creator = '创建人';
+        createTime = '创建时间';
+        updator = '更新人';
+        updateTime = '更新时间';
+    } else if (config.lang === 'en') {
+        recordNumber = 'Record_number';
+        creator = 'Created_by';
+        createTime = 'Created_datetime';
+        updator = 'Updated_by';
+        updateTime = 'Updated_datetime';
     }
-    
+
 
     // 全アプリ取得用のDeffered
     var d = new $.Deferred();
@@ -44,14 +44,14 @@ jQuery.noConflict();
 
     var folderIcon = config['folderIcon'];
     var appIcon = config['appIcon'];
-    var vc_type = ['folder', 'file', 'tree', 'leaf', 'home',
-    'arrowRight', 'asterisk', 'bell', 'handRight', 'heart', 'heartEmpty'];
+    var vcType = ['folder', 'file', 'tree', 'leaf', 'home',
+        'arrowRight', 'asterisk', 'bell', 'handRight', 'heart', 'heartEmpty'];
 
     // 全アプリ取得関数
-    function fetchApps(opt_offset, opt_limit, opt_records) {
-        var offset = opt_offset || 0;
-        var limit = opt_limit || 100;
-        var allRecords = opt_records || [];
+    function fetchApps(optOffset, optLimit, optRecords) {
+        var offset = optOffset || 0;
+        var limit = optLimit || 100;
+        var allRecords = optRecords || [];
         return kintone.api(kintone.api.url('/k/v1/apps', true), 'GET', {
             limit: limit,
             offset: offset
@@ -66,10 +66,10 @@ jQuery.noConflict();
     }
 
     // 全レコード取得関数
-    function fetchRecords(appId, query, opt_offset, opt_limit, opt_records) {
-        var offset = opt_offset || 0;
-        var limit = opt_limit || 100;
-        var allRecords = opt_records || [];
+    function fetchRecords(appId, query, optOffset, optLimit, optRecords) {
+        var offset = optOffset || 0;
+        var limit = optLimit || 100;
+        var allRecords = optRecords || [];
         var params = {
             app: appId,
             query: query + ' limit ' + limit + ' offset ' + offset
@@ -84,14 +84,14 @@ jQuery.noConflict();
     }
 
     // 全レコード削除関数
-    function deleteRecords(appId, delIds, opt_offset, opt_limit) {
-        var offset = opt_offset || 0;
-        var limit = opt_limit || 100;
+    function deleteRecords(appId, delIds, optOffset, optLimit) {
+        var offset = optOffset || 0;
+        var limit = optLimit || 100;
         var finishFlg = 0;
         var ids = [];
 
         for (var i = offset, j = 0; j < limit; i++, j++) {
-            if (typeof (delIds[i]) === "undefined") {
+            if (typeof (delIds[i]) === 'undefined') {
                 finishFlg = 1;
                 break;
             }
@@ -116,6 +116,14 @@ jQuery.noConflict();
         );
     }
 
+    function removeLoading() {
+        var $loading = $('.loading');
+        $loading.remove();
+
+        var $body = $('body');
+        $body.css('position', '');
+    }
+
     // ローディング画面
     function setLoading() {
     // モーダルでローディング画像を表示
@@ -123,9 +131,10 @@ jQuery.noConflict();
         $body.css('width', '100%');
 
         var $loading = $('<div>').attr('id', 'loading').attr('class', 'loading')
-        .attr('style', 'width: 100%; height: 100%; position:absolute;' +
+            .attr('style', 'width: 100%; height: 100%; position:absolute;' +
         ' top:0; left:0; text-align:center; background-color:#666666; opacity:0.6; z-index: 9;');
         var $div = $('<div>').attr('id', 'imgBox').attr('style', 'width: 100%; height: 100%;');
+        // eslint-disable-next-line max-len
         var $img = $('<img>').attr('src', 'data:image/gif;base64,R0lGODlhZABkAPQAAAAAAP///3BwcJaWlsjIyMLCwqKiouLi4uzs7NLS0qqqqrKysoCAgHh4eNra2v///4iIiLq6uvT09AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH+GkNyZWF0ZWQgd2l0aCBhamF4bG9hZC5pbmZvACH5BAAHAAAAIf8LTkVUU0NBUEUyLjADAQAAACwAAAAAZABkAAAF/yAgjmRpnmiqrmzrvnAsz3Rt33iu73zfMgoDw0csAgSEh/JBEBifucRymYBaaYzpdHjtuhba5cJLXoHDj3HZBykkIpDWAP0YrHsDiV5faB3CB3c8EHuFdisNDlMHTi4NEI2CJwWFewQuAwtBMAIKQZGSJAmVelVGEAaeXKEkEaQSpkUNngYNrCWEpIdGj6C3IpSFfb+CAwkOCbvEy8zNzs/Q0dLT1NUrAgOf1kUMBwjfB8rbOQLe3+C24wxCNwPn7wrjEAv0qzMK7+eX2wb0mzXu8iGIty1TPRvlBKazJgBVnBsN8okbRy6VgoUUM2rcyLGjx48gQ4ocSbKkyZMoJf8JMFCAwAJfKU0gOUDzgAOYHiE8XDGAJoKaalAoObHERFESU0oMFbF06YikKQQsiKCJBYGaNR2ocPr0AQCuQ8F6Fdt1rNeuLSBQjRDB3qSfPm1uPYvUbN2jTO2izQs171e6J9SuxXjCAFaaQYkC9ku2MWCnYR2rkDqV4IoEWG/O5fp3ceS7nuk2Db0YBQS3UVm6xBmztevXsGPLnk27tu3buHOvQU3bgIPflscJ4C3D92/gFNUWgHPj2G+bmhkWWL78xvPjDog/azCdOmsXzrF/dyYgAvUI7Y7bDF5N+QLCM4whM7BxvO77+PPr38+//w4GbhSw0xMQDKCdJAwkcIx2ggMSsQABENLHzALILDhMERAQ0BKE8IUSwYILPjEAhCQ2yMoCClaYmA8NQLhhh5I0oOCCB5rAQI0mGEDiRLfMQhWOI3CXgIYwotBAA/aN09KQCVw4m4wEMElAkTEhIWUCSaL0IJPsySZVlC/5J+aYZJZppgghAAAh+QQABwABACwAAAAAZABkAAAF/yAgjmRpnmiqrmzrvnAsz3Rt33iu73zfMhAIw0csAgQDhESCGAiM0NzgsawOolgaQ1ldIobZsAvS7ULE6BW5vDynfUiFsyVgL58rwQLxOCzeKwwHCIQHYCsLbH95Dg+OjgeAKAKDhIUNLA2JVQt4KhGPoYuSJEmWlgYuSBCYLRKhjwikJQqnlgpFsKGzJAa2hLhEuo6yvCKUv549BcOjxgOVhFdFdbAOysYNCgQK2HDMVAXexuTl5ufo6err7O3kAgKs4+48AhEH+ATz9Dj2+P8EWvET0YDBPlX/Eh7i18CAgm42ICT8l2ogAAYPFSyU0WAiPjcDtSkwIHCGAAITE/+UpCeg4EqTKPGptEikpQEGL2nq3Mmzp8+fQIMKHUq0qNGjSJO6E8DA4RyleQw4mOqgk1F4LRo4OEDVwTQUjk48MjGWxC6zD0aEBbBWbdlJBhYsAJlC6lSuDiKoaOuWbdq+fMMG/us37eCsCuRaVWG3q94UfEUIJlz48GHJsND6VaFJ8UEAWrdS/SqWMubNgClP1nz67ebIJQTEnduicdWDZ92aXq17N+G1kV2nwEqnqYGnUJMrX868ufPn0KNLn069Or+N0hksSFCArkWmORgkcJCgvHeWCiIYOB9jAfnx3D+fE5A+woKKNSLAh4+dXYMI9gEonwoKlPeeON8ZAOCgfTc0UB5/OiERwQA5xaCJff3xM6B1HHbo4YcghigiNXFBhEVLGc5yEgEJEKBPFBBEUEAE7M0yAIs44leTjDNGUKEkBrQopDM+NFDAjEf+CMiNQhJAWpE8zqjkG/8JGcGGIjCQIgoMyOhjOkwNMMCWJTTkInJZNYAlPQYU4KKT0xnpopsFTKmUPW8ScOV0N7oJ53TxJAbBmiMWauihiIIYAgAh+QQABwACACwAAAAAZABkAAAF/yAgjmRpnmiqrmzrvnAsz3Rt33iu73zv/8AZo4BAFBjBpI5xKBYPSKWURnA6CdNszGrVeltc5zcoYDReiXDCBSkQCpDxShA52AuCFoQribMKEoGBA3IpdQh2B1h6TQgOfisDgpOQhSMNiYkIZy4CnC0Ek4IFliVMmnYGQAmigWull5mJUT6srRGwJESZrz+SrZWwAgSJDp8/gJOkuaYKwUADCQ4JhMzW19jZ2tvc3d7f4NoCCwgPCAs4AwQODqrhIgIOD/PzBzYDDgfsDgrvAAX0AqKjIW0fuzzhJASk56CGwXwOaH1bGLBGQX0H31Gch6CGgYf93gGkOJCGgYIh3/8JUBjQHg6J/gSMlBABob+bOHPq3Mmzp8+fQIMKHUq0qNEUAiBAOHZ0RYN10p41PZGg6jQHNk/M07q1BD2vX0l0BdB1rIiKKhgoMMD0BANpVqmpMHv2AVm7I7aa1Yu3bl6+YvuuUEDYXdq40qqhoHu38d+wfvf2pRjYcYq1a0FNg5vVBGPAfy03lhwa8mjBJxqs7Yzi6WapgemaPh0b9diythnjSAqB9dTfwIMLH068uPHjyJMrX84cnIABCwz4Hj4uAYEEeHIOMAAbhjrr1lO+g65gQXcX0a5fL/nOwIL3imlAUG/d8DsI7xfAlEFH/SKcEAywHw3b9dbcgQgmqOByggw26KAIDAxwnnAGEGAhe0AIoEAE0mXzlBsWTojDhhFwmE0bFroR3w8RLNAiLtg8ZaGFbfVgwIv2WaOOGzn+IIABCqx4TRk1pkXYgMQNUUAERyhnwJIFFNAjcTdGaWJydCxZ03INBFjkg2CGKeaYCYYAACH5BAAHAAMALAAAAABkAGQAAAX/ICCOZGmeaKqubOu+cCzPdG3feK7vfO//wBnDUCAMBMGkTkA4OA8EpHJKMzyfBqo2VkBcEYWtuNW8HsJjoIDReC2e3kPEJRgojulVPeFIGKQrEGYOgCoMBwiJBwx5KQMOkJBZLQILkAuFKQ2IiYqZjQANfA4HkAltdKgtBp2tA6AlDJGzjD8KrZ0KsCSipJCltT63uAiTuyIGsw66asQHn6ACCpEKqj8DrQevxyVr0D4NCgTV3OXm5+jp6uvs7e7v6gIQEQkFEDgNCxELwfACBRICBtxGQ1QCPgn6uRsgsOE9GgoQ8inwLV2ChgLRzKCHsI9Cdg4wBkxQw9LBPhTh/wG4KHIODQYnDz6Ex1DkTCEL6t189w+jRhsf/Q04WACPyqNIkypdyrSp06dQo0qdSrWqVUcL+NER0MAa1AYOHoh9kKCiiEoE6nl1emDsWAIrcqYlkDKF2BNjTeQl4bbEXRF//47oe8KABLdjg4qAOTcBAcWAH+iVLBjA3cqXJQ/WbDkzX84oFCAey+wEg8Zp136e3Pnz3sitN28mDLsyiQWjxRo7EaFxXRS2W2OmDNqz7NrDY5swkPsB5FC91a6gHRm08OKvYWu3nd1EW8Rw9XA1q1TAd7Flr76wo1W9+/fw48ufT7++/fv48+s/wXUABPLwCWAAAQRiolQD/+FDIKRdBOz0TjgKkGNDAwsSSJBKEESowHOUEFjEY0lJEyGAegyw4G5HNcAAiS0g2ACL+8Uo44w01mjjjTi+wMCKMs5TQAQO+iCPAQme00AEP/4IIw0DZLVAkLA0kGQBBajGQ5MLKIDiMUcmGYGVO0CQZXvnCIAkkFOsYQCH0XQVAwP+sRlgVvssadU8+6Cp3zz66JmfNBFE8EeMKrqZ46GIJqrooi6EAAAh+QQABwAEACwAAAAAZABkAAAF/yAgjmRpnmiqrmzrvnAsz3Rt33iu73zv/0Baw2BoBI88g2N5MCCfNgZz6WBArzEl1dHEeluGw9Sh+JpTg+1y8GpABGdWQxFZWF0L7nLhEhAOgBFwcScNCYcOCXctAwsRbC5/gIGEJwuIh3xADJOdg5UjEQmJowlBYZ2AEKAkeZgFQZypB0asIgyYCatBCakEtiQMBQkFu0GGkwSfwGYQBovM0dLT1NXW19jZ2ts+AgYKA8s0As6Q3AADBwjrB9AzogkEytwN6uvs4jAQ8fxO2wr3ApqTMYAfgQSatBEIeK8MjQEHIzrUBpAhgoEyIkSct62BxQP5YAhoZCDktQEB2/+d66ZAQZGVMGPKnEmzps2bOHPq3Mmzp88v5Iz9ZLFAgtGLjCIU8IezqFGjDzCagCBPntQSDx6cyKoVa1avX0mEBRB2rAiuXU00eMoWwQoF8grIW2H2rFazX/HeTUs2Lde+YvmegMCWrVATC+RWpSsYsN6/I/LyHYtWL+ATAwo/PVyCatWrgU1IDm3Zst2+k/eiEKBZgtsVA5SGY1wXcmTVt2v77aq7cSvNoIeOcOo6uPARAhhwPs68ufPn0KNLn069uvXrfQpklSAoRwOT1lhXdgC+BQSlEZZb0175QcJ3Sgt039Y+6+sZDQrI119LW/26MUQQ33zaSFDfATY0kFh2euewV9l748AkwAGVITidAAA9gACE2HXo4YcghijiiN0YEIEC5e3QAAP9RWOiIxMd0xKK0zhSRwRPMNCSAepVYoCNTMnoUopxNDLbEysSuVIDLVLXyALGMSfAAgsosICSP01J5ZXWQUBlj89hSeKYZJZpJoghAAAh+QQABwAFACwAAAAAZABkAAAF/yAgjmRpnmiqrmzrvnAsz3Rt33iu73zv/0Bag8FoBI+8RmKZMCKfNQbTkSAIoNgYZElNOBjZcGtLLUPE6JSg601cXQ3IO60SQAzyF9l7bgkMbQNzdCUCC1UJEWAuAgOCLwYOkpIDhCdbBIiVQFIOB5IHVpYlBpmmC0EMk6t9oyIDplUGqZ+ek06uAAwEpqJBCqsOs7kjDAYLCoM/DQa1ycSEEBCL0NXW19jZ2tvc3d7fPwJDAsoz4hC44AIFB+0R5TGwvAbw2Q0E7fnvNQIEBbwEqHVj0A5BvgPpYtzj9W+TNwUHDR4QqBAgr1bdIBzMlzCGgX8EFtTD1sBTPgQFRv/6YTAgDzgAJfP5eslDAAMFDTrS3Mmzp8+fQIMKHUq0qNGjSJMisYNR6YotCBAE9GPAgE6fEKJqnbiiQYQCYCmaePDgBNmyJc6mVUuC7Ai3AOC+ZWuipAStUQusGFDgawQFK+TOjYtWhFvBhwsTnlsWseITDfDibVoCAtivgFUINtxY8VnHiwdz/ty2MwoBkrVSJtEAbNjAjxeDnu25cOLaoU2sSa236wCrKglvpss5t/DHcuEO31z57laxTisniErganQSNldf3869u/fv4MOLH0++vHk/A5YQeISjQfBr6yTIl5/Sxp2/76sNmM9fuwsDESyAHzgJ8DdfbzN4JWCkBBFYd40DBsqXgA0DMIhMfsQUGGEENjRQIR4v7Rehfy9gWE18/DkEnh0RJELieTDGKOOMNAa1DlkS1Bceap894ICJUNjhCJAyFNAjWahAA8ECTKrow5FkIVDNMcgMAwSUzFnCAJMLvHiDBFBKWQ1LLgERAZRJBpVTiQ70eMBQDSigAHSnLYCAj2kCJYCcBjwz3h98EnkUM1adJ2iNiCaq6KKLhgAAIfkEAAcABgAsAAAAAGQAZAAABf8gII5kaZ5oqq5s675wLM90bd94ru987//AoHAYEywShIWAyKwtCMjEokmFCaJQwrLKVTWy0UZ3jCqAC+SfoCF+NQrIQrvFWEQU87RpQOgbYg0MMAwJDoUEeXoiX2Z9iT0LhgmTU4okEH0EZgNCk4WFEZYkX5kEEEJwhoaVoiIGmklDEJOSgq0jDAOnRBBwBba3wcLDxMXGx8jJysvMzUJbzgAGn7s2DQsFEdXLCg4HDt6cNhHZ2dDJAuDqhtbkBe+Pxgze4N8ON+Tu58jp6+A3DPJtU9aNnoM/OBrs4wYuAcJoPYBBnEixosWLGDNq3Mixo8ePIEOKxGHEjIGFKBj/DLyY7oDLA1pYKIgQQcmKBw9O4MxZYmdPnyRwjhAKgOhQoCcWvDyA4IC4FAHtaLvJM2hOo0WvVs3K9ehRrVZZeFsKc0UDmnZW/jQhFOtOt2C9ingLt+uJsU1dolmhwI5NFVjnxhVsl2tdwkgNby0RgSyCpyogqGWbOOvitlvfriVc2LKKli9jjkRhRNPJ0ahTq17NurXr17Bjy55NG0UDBQpOvx6AoHdTiTQgGICsrIFv3wdQvoCwoC9xZAqO+34Ow0DfBQ+VEZDeW4GNOgsWTC4WnTv1QQaAJ2vA9Hhy1wPaN42XWoD1Acpr69/Pv79/ZgN8ch5qBUhgoIF7BSMAfAT07TDAgRCON8ZtuDWYQwIQHpigKAzgpoCEOGCYoQQJKGidARaaYB12LhAwogShKMhAiqMc8JYDNELwIojJ2EjXAS0UCOGAywxA105EjgBBBAlMZdECR+LESmpQRjklagxE+YB6oyVwZImtCUDAW6K51mF6/6Wp5po2hAAAIfkEAAcABwAsAAAAAGQAZAAABf8gII5kaZ5oqq5s675wLM90bd94ru987//AoHAYE0AWC4iAyKwNCFDCoEmFCSJRQmRZ7aoaBWi40PCaUc/o9OwTNMqvhiE84LYYg4GSnWpEChEQMQ0MVlgJWnZ8I36AgHBAT4iIa4uMjo9CC5MECZWWAI2Oij4GnaefoEcFBYVCAlCIBK6gIwwNpEACCgsGubXAwcLDxMXGx8jJysvMZ7/KDAsRC5A1DQO9z8YMCQ4J39UzBhHTCtrDAgXf3gkKNg3S0hHhx9zs3hE3BvLmzOnd6xbcYDCuXzMI677RenfOGAR1CxY26yFxosWLGDNq3Mixo8ePIEOKHEmyZDEBAwz/GGDQcISAlhMFLHBwwIEDXyyOZFvx4MGJnj5LABU6lETPEUcBJEVa9MQAm1Ad0CshE4mCqUaDZlWqlatXpl9FLB26NGyKCFBr3lyxCwk1nl3F+iwLlO7crmPr4r17NqpNAzkXKMCpoqxcs0ftItaaWLFhEk9p2jyAlSrMukTjNs5qOO9hzipkRiVsMgXKwSxLq17NurXr17Bjy55Nu7ZtIoRWwizZIMGB3wR2f4FQuVjv38gLCD8hR8HVg78RIEdQnAUD5woqHjMgPfpv7S92Oa8ujAHy8+TZ3prYgED331tkp0Mef7YbJctv69/Pv7//HOlI0JNyQ+xCwHPACOCAmV4S5AfDAAhEKF0qfCyg14BANCChhAc4CAQCFz6mgwIbSggYKCGKmAOJJSLgDiggXiiBC9cQ5wJ3LVJ4hoUX5rMCPBIEKcFbPx5QYofAHKAXkissIKSQArGgIYfgsaGAki62JMCTT8J0Wh0cQcClkIK8JuaYEpTpGgMIjIlAlSYNMKaOq6HUpgQIgDkbAxBAAOd/gAYqKA0hAAAh+QQABwAIACwAAAAAZABkAAAF/yAgjmRpnmiqrmzrvnAsz3Rt33iu73zv/8CgcChrQAYNotImiBQKi+RyCjM4nwOqtmV4Og3bcIpRuDLEaBNDoTjDGg1BWmVQGORDA2GfnZusCxFgQg17BAUEUn4jEYGNQwOHhhCLJFYREQpDEIZ7ipUCVgqfQAt7BYOVYkduqq6vsLGys7S1tre4ubq7UwIDBn04DAOUuwJ7CQQReDUMC8/FuXrJydE0Bs92uwvUBAnBNM7P4LcK3ufkMxDAvMfnBbw9oQsDzPH3+Pn6+/z9/v8AAwocSLCgwYO9IECwh9AEBAcJHCRq0aAOqRMPHmDMaCKjRhIeP47gKIIkyZEeU/8IgMiSABc2mlacRAlgJkebGnGizCmyZk8UAxIIHdoqRR02LGaW5AkyZFOfT5c6pamURFCWES+aCGWgKIqqN3uGfapzqU+xTFEIiChUYo+pO0uM3fnzpMm6VUs8jDixoVoIDBj6HUy4sOHDiBMrXsy4sWMSTSRkLCD4ltcZK0M+QFB5lgIHEFPNWKB5cq7PDg6AFh0DQem8sVaCBn0gQY3XsGExSD0bdI0DryXgks0bYg3SpeHhQj07HQzgIR10lmWAr/MYC1wjWDD9sffv4MOLR3j1m5J1l/0UkMCevXIgDRIcQHCAQHctENrrv55D/oH/B7ynnn7t2fYDAwD+R59zVmEkQCB7BvqgQIIAphdGBA9K4JILcbzQAID0/cfgFvk9aE0KDyFA34kp+AdgBK4MQKCAKEqg4o0sniBAAQBS9goEESQQQY4nJHDjjRGy0EBg/Rx55GFO3ngYAVFuWBiCRx4w4kENFKBiAVuOJ+aYZIoZAgAh+QQABwAJACwAAAAAZABkAAAF/yAgjmRpnmiqrmzrvnAsz3Rt33iu73zv/8CgcChrMBoNotImUCwiiuRyCoNErhEIdduCPJ9arhgleEYWgrHaxIBAGDFkep1iGBhzobUQkdJLDAtOYUENEXx8fn8iBguOBkMNiImLJF6CA0MCBYh9lSMCEAYQikAMnBFwn2MCRquvsLGys7S1tre4ubq7vDqtpL5HvAIGBMYDeTTECgrJtwwEBcYEzjIMzKO7A9PGpUUGzN61EMbSBOIxoei0ZdOQvTuhAw3V8Pb3+Pn6+/z9/v8AAwocSBCQo0wFUwhI8KDhgwPrerUSUK8EAYcOD/CTRCABGhUMMGJ8d6JhSZMlHP+mVEkCJQCULkVgVFggQUcCC1QoEOlQQYqYMh+8FDrCZEyjRIMWRdoyaZ2bNhOoOmGAZ8OcKIAO3bqUpdKjSXk25XqiQdSb60JaJWlCK9OlZLeChetVrtMSm85iTXFRpMafdYfefRsUqEuYg7WWkGTTk4qFGB1EHEavIpuDCTNr3sy5s+fPoEOLHk063YCaCZD1mlpjk4TXrwtYjgWh5gLWMiDA3o3wFoQECRwExw2jwG7YCXDlFS58r4wEx187wMUgOHDgEWpEiC4h+a281h34pKE7em9b1YUDn7xiwHHZugKdYc/CSoIss0vr38+/v//RTRAQhRIC4AHLAAcgoCCkAuf50IACDkTYzCcCJLiggvTRAKEDB0TIFh0GXLjgeD4wwGGEESaQIREKiKggiT2YiOKJxI0xgIsIfKgCPS+YFWGHwq2oiYULHpCfCFZE+FELBszoQIN0NEDkATWaIACHB2TpwJEAEGOdaqsIMIACYLKwQJZoHuDcCkZweUsBaCKQJQGfEZBmlgV8ZkCCceqYWXVpUgOamNEYIOR/iCaq6KIAhAAAIfkEAAcACgAsAAAAAGQAZAAABf8gII5kaZ5oqq5s675wLM90bd94ru987//AoHBIExCPOMhiAUE6ZYLl0vissqJSqnWLGiwUA64Y1WiMfwKGmSgwgM+otsKwFhoWkYgBbmIo/gxEeXgLfCUNfwp1QQp4eoaHakdRelqQl5iZmpucnZ6foKGioz8LCA8IC5akOAcPr68Oq6CzMguwuAWjEBEFC4syDriwEqICvcg2w7iiDQXPBRHAMKfLD8bR0RE2t8u6ogzPEU01AsK4ErWdAtMzxxKvBeqs9PX29/j5+vv8/f7/AAMKNAEBwryBJAYgkMCwEMIUAxhKlOBQn4AB0cKsWDiRYTsRr07AMjGSBDOT10D/pgyJkmUXAjAJkEMBoaPEmSRTogTgkue1niGB6hwptAXMAgR8qahpU4JGkTpHBI06bGdRlSdV+lQRE6aCjU3n9dRatCzVoT/NqjCAFCbOExE7VoQ6tqTUtC2jbtW6967eE2wjPFWhUOLchzQNIl7MuLHjx5AjS55MubJlGQ3cKDj4kMEBBKARDKZ1ZwDnFQI+hwb9UZMAAglgb6uhcDXor6EUwN49GoYC26AJiFoQu3jvF7Vt4wZloDjstzBS2z7QWtPuBKpseA594LinAQYU37g45/Tl8+jTq19fmUF4yq8PfE5QPQeEAgkKBLpUQL7/BEJAkMCADiSwHx8NyIeAfH8IHOgDfgUm4MBhY0Dg34V7ACEhgQnMxocACyoon4M9EBfhhJdEcOEBwrkwQAQLeHcCAwNKSEB9VRzjHwHmAbCAA0Ci6AIDeCjiGgQ4jjBAkAcAKSNCCgQZ5HKOGQBkk0Bm+BgDUjZJYmMGYOmAlpFlRgd7aKap5poyhAAAIfkEAAcACwAsAAAAAGQAZAAABf8gII5kaZ5oqq5s675wLM90bd94ru987//AoHBIExCPOIHB0EA6ZUqFwmB8WlkCqbR69S0cD8SCy2JMGd3f4cFmO8irRjPdW7TvEaEAYkDTTwh3bRJCEAoLC35/JIJ3QgaICwaLJYGND0IDkRCUJHaNBXoDAxBwlGt3EqadRwIFEmwFq6y0tba3uLm6u7y9viYQEQkFpb8/AxLJybLGI7MwEMrSA81KEQNzNK/SyQnGWQsREZM1CdzJDsYN4RHh2TIR5xLev1nt4zbR59TqCuOcNVxxY1btXcABBBIkGPCsmcOHECNKnEixosWLGDNq3MjxCIRiHV0wIIAAQQKAIVX/MDhQsqQElBUFNFCAjUWBli0dGGSEyUQbn2xKOOI5IigAo0V/pmBQIEIBgigg4MS5MynQoz1FBEWKtatVrVuzel2h4GlTflGntnzGFexYrErdckXaiGjbEv6aEltxc+qbFHfD2hUr+GvXuIfFmmD6NEJVEg1Y4oQJtC3ixDwtZzWqWfGJBksajmhA0iTllCk+ikbNurXr17Bjy55Nu7bt20HkKGCwOiWDBAeC63S4B1vvFAIIBF+e4DEuAQsISCdHI/Ly5ad1QZBeQLrzMssRLFdgDKF0AgUUybB+/YB6XiO7Sz9+QkAE8cEREPh+y8B5hjbYtxxU6kDQAH3I7XEgnG4MNujggxBGCAVvt2XhwIUK8JfEIX3YYsCFB2CoRwEJJEQAgkM0ANyFLL7HgwElxphdGhCwCKIDLu4QXYwEUEeJAAnc6EACOeowAI8n1TKAjQ74uIIAo9Bnn4kRoDgElEEmQIULNWY54wkMjAKSLQq+IMCQQwZp5UVdZpnkbBC4OeSXqCXnJpG1qahQc7c1wAADGkoo6KCEFrpCCAA7AAAAAAAAAAAA');
         $loading.append($div.append($img));
         $body.append($loading);
@@ -144,18 +153,10 @@ jQuery.noConflict();
         }, 1000);
     }
 
-    function removeLoading() {
-        var $loading = $('.loading');
-        $loading.remove();
-
-        var $body = $('body');
-        $body.css('position', '');
-    }
-
     // jstree準備関数
     function readyTree(event) {
         setLoading();
-        $("#tree").jstree("destroy");
+        $('#tree').jstree('destroy');
         d = new $.Deferred();
         d2 = new $.Deferred();
         data = [];
@@ -164,10 +165,10 @@ jQuery.noConflict();
 
         // rootフォルダのアイコンを確定させる
         switch (config.folderIcon) {
-            case "folder":
+            case 'folder':
                 rootIcon = 'jstree-folder';
                 break;
-            case "tree":
+            case 'tree':
                 rootIcon = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAA' +
                     'QCAYAAAAf8/9hAAACZUlEQVR42oWTTUhUURTHf88ZP5px7DXpmI6lEKi1Gj' +
                     'ctKm36WoREz0UUEqiLoKAoFyK08aMiKGLGWmQQOdBGaGEKGdRCA2lRkNIim' +
@@ -185,255 +186,256 @@ jQuery.noConflict();
                     'nj+SH8K32VNcReMT6nG4/qlveYg2np7sjn1HWFQEb+B/hThmHrrBl4F+akb' +
                     'jmLeHCl/28Ig0BcPhKKzAAAAABJRU5ErkJggg==';
                 break;
-            case "leaf":
-                rootIcon = "glyphicon glyphicon-leaf";
+            case 'leaf':
+                rootIcon = 'glyphicon glyphicon-leaf';
                 break;
-            case "home":
-                rootIcon = "glyphicon glyphicon-home";
+            case 'home':
+                rootIcon = 'glyphicon glyphicon-home';
                 break;
-            case "arrowRight":
-                rootIcon = "glyphicon glyphicon-arrow-right";
+            case 'arrowRight':
+                rootIcon = 'glyphicon glyphicon-arrow-right';
                 break;
-            case "asterisk":
-                rootIcon = "glyphicon glyphicon-asterisk";
+            case 'asterisk':
+                rootIcon = 'glyphicon glyphicon-asterisk';
                 break;
-            case "bell":
-                rootIcon = "glyphicon glyphicon-bell";
+            case 'bell':
+                rootIcon = 'glyphicon glyphicon-bell';
                 break;
-            case "handRight":
-                rootIcon = "glyphicon glyphicon-hand-right";
+            case 'handRight':
+                rootIcon = 'glyphicon glyphicon-hand-right';
                 break;
-            case "heart":
-                rootIcon = "glyphicon glyphicon-heart";
+            case 'heart':
+                rootIcon = 'glyphicon glyphicon-heart';
                 break;
-            case "heartEmpty":
-                rootIcon = "glyphicon glyphicon-heart-empty";
+            case 'heartEmpty':
+                rootIcon = 'glyphicon glyphicon-heart-empty';
                 break;
         }
 
 
         // すでにログインユーザーに紐づくレコードがあるかどうか（初期状態か否か）
         fetchRecords(event.appId, creator + ' in ("' + kintone.getLoginUser().code + '") and parentFolderID = ""')
-        .then(function(rootRec) {
-            if (rootRec.length > 0) {
-                data[0] = {
-                    text: rootRec[0].folderName.value,
-                    class: "jstree-open",
-                    type: 'root',
-                    children: [],
-                    self: "j1_1"
-                };
-                fetchRecords(event.appId, creator + ' in ("' + kintone.getLoginUser().code +
+            .then(function(rootRec) {
+                if (rootRec.length > 0) {
+                    data[0] = {
+                        text: rootRec[0].folderName.value,
+                        class: 'jstree-open',
+                        type: 'root',
+                        children: [],
+                        self: 'j1_1'
+                    };
+                    fetchRecords(event.appId, creator + ' in ("' + kintone.getLoginUser().code +
                 '") and parentFolderID != "" order by appSort asc').then(function(selfRecords) {
-                    for (var j = 0; j < selfRecords.length; j++) {
+                        for (var j = 0; j < selfRecords.length; j++) {
                         // フォルダの場合
-                        if (!selfRecords[j].appName.value) {
+                            if (!selfRecords[j].appName.value) {
+                                children.push({
+                                    text: selfRecords[j].folderName.value,
+                                    class: 'jstree-open',
+                                    type: folderIcon,
+                                    children: [],
+                                    self: selfRecords[j].selfFolderID.value,
+                                    parentFolderID: selfRecords[j].parentFolderID.value,
+                                    appSort: selfRecords[j].appSort.value
+                                });
+                            } else {
+                                children.push({
+                                    text: selfRecords[j].appName.value,
+                                    type: appIcon,
+                                    attr: {
+                                        'href': 'https://' + location.host + '/k/' + selfRecords[j].appID.value + '/'
+                                    },
+                                    parentFolderID: selfRecords[j].parentFolderID.value,
+                                    appSort: selfRecords[j].appSort.value,
+                                    appId: selfRecords[j].appID.value
+                                });
+                            }
+                        }
+
+                        // フォルダの子階層を設定
+                        var currentFolder;
+                        var jissitsuSort = 0;
+                        var deleteKey = [];
+                        for (var ckey in children) {
+                            if (children[ckey].type === folderIcon) {
+                                if (typeof (children[parseInt(ckey, 10) + 1]) !== 'undefined' &&
+                            children[parseInt(ckey, 10) + 1].parentFolderID === children[ckey].self) {
+                                    currentFolder = ckey;
+                                    if (!folderInfo[jissitsuSort]) {
+                                        folderInfo[jissitsuSort] = [];
+                                    }
+                                    continue;
+                                }
+                            }
+                            if (children[ckey].parentFolderID !== 'j1_1') {
+                                folderInfo[jissitsuSort].push(children[ckey]);
+                                children[currentFolder].children.push(children[ckey]);
+                                deleteKey.push(ckey);
+                            } else {
+                                jissitsuSort++;
+                            }
+                            if (typeof (children[parseInt(ckey, 10) + 1]) !== 'undefined' &&
+                        children[parseInt(ckey, 10) + 1].parentFolderID === 'j1_1' &&
+                        children[ckey].parentFolderID !== 'j1_1') {
+                                jissitsuSort++;
+                            }
+                        }
+
+                        var delCnt = 0;
+                        for (var dkey in deleteKey) {
+                            childNodeInfo.push(children[deleteKey[dkey] - delCnt]);
+                            children.splice(deleteKey[dkey] - delCnt, 1);
+                            delCnt++;
+                        }
+
+                        data[0].children = children;
+                        d2.resolve();
+                    });
+                } else {
+                // 全アプリ取得
+                    fetchApps();
+
+                    d.promise().then(function() {
+                    // 取得した全アプリをアプリIDの降順に並び替え
+                        apps.sort(function(a, b) {
+                            if (parseInt(a.appId, 10) > parseInt(b.appId, 10)) {
+                                return -1;
+                            }
+                            if (parseInt(a.appId, 10) < parseInt(b.appId, 10)) {
+                                return 1;
+                            }
+                            return 0;
+                        });
+                        for (var i = 0; i < apps.length; i++) {
                             children.push({
-                                text: selfRecords[j].folderName.value,
-                                class: "jstree-open",
-                                type: folderIcon,
-                                children: [],
-                                self: selfRecords[j].selfFolderID.value,
-                                parentFolderID: selfRecords[j].parentFolderID.value,
-                                appSort: selfRecords[j].appSort.value
-                            });
-                        } else {
-                            children.push({
-                                text: selfRecords[j].appName.value,
+                                text: apps[i].name,
                                 type: appIcon,
                                 attr: {
-                                    "href": "https://" + location.host + "/k/" + selfRecords[j].appID.value + "/"
-                                },
-                                parentFolderID: selfRecords[j].parentFolderID.value,
-                                appSort: selfRecords[j].appSort.value,
-                                appId: selfRecords[j].appID.value
+                                    'href': 'https://' + location.host + '/k/' + apps[i].appId + '/'
+                                }
                             });
                         }
-                    }
+                        var appIndex = 'アプリ一覧';
+                        if (config.lang === 'zh') {
+                            appIndex = '软件连接一览';
+                        } else if (config.lang === 'en') {
+                            appIndex = 'app index';
+                        }
+                        data = [{
+                            text: appIndex,
+                            class: 'jstree-open',
+                            children: children,
+                            type: 'root'
+                        }];
 
-                    // フォルダの子階層を設定
-                    var currentFolder;
-                    var jissitsuSort = 0;
-                    var deleteKey = [];
-                    for (var ckey in children) {
-                        if (children[ckey].type === folderIcon) {
-                            if (typeof (children[parseInt(ckey, 10) + 1]) !== "undefined" &&
-                            children[parseInt(ckey, 10) + 1].parentFolderID === children[ckey].self) {
-                                currentFolder = ckey;
-                                if (!folderInfo[jissitsuSort]) {
-                                    folderInfo[jissitsuSort] = [];
-                                }
-                                continue;
+                        var recCount = apps.length;
+                        var putCount = Math.ceil(recCount / 100);
+                        for (var k = 0; k < putCount; k++) {
+                            var offset = k * 100;
+                            var limit = 100;
+                            if (offset + limit > recCount) {
+                                limit = recCount - offset;
                             }
-                        }
-                        if (children[ckey].parentFolderID !== "j1_1") {
-                            folderInfo[jissitsuSort].push(children[ckey]);
-                            children[currentFolder].children.push(children[ckey]);
-                            deleteKey.push(ckey);
-                        } else {
-                            jissitsuSort++;
-                        }
-                        if (typeof (children[parseInt(ckey, 10) + 1]) !== "undefined" &&
-                        children[parseInt(ckey, 10) + 1].parentFolderID === "j1_1" &&
-                        children[ckey].parentFolderID !== "j1_1") {
-                            jissitsuSort++;
-                        }
-                    }
+                            var putLimit = limit + offset;
+                            var insRecords = [];
 
-                    var delCnt = 0;
-                    for (var dkey in deleteKey) {
-                        childNodeInfo.push(children[deleteKey[dkey] - delCnt]);
-                        children.splice(deleteKey[dkey] - delCnt, 1);
-                        delCnt++;
-                    }
-
-                    data[0].children = children;
-                    d2.resolve();
-                });
-            } else {
-                // 全アプリ取得
-                fetchApps();
-
-                d.promise().then(function() {
-                    // 取得した全アプリをアプリIDの降順に並び替え
-                    apps.sort(function(a, b) {
-                        if (parseInt(a.appId, 10) > parseInt(b.appId, 10)) {
-                            return -1;
-                        }
-                        if (parseInt(a.appId, 10) < parseInt(b.appId, 10)) {
-                            return 1;
-                        }
-                        return 0;
-                    });
-                    for (var i = 0; i < apps.length; i++) {
-                        children.push({
-                            text: apps[i].name,
-                            type: appIcon,
-                            attr: {
-                                "href": "https://" + location.host + "/k/" + apps[i].appId + "/"
+                            for (offset; offset < putLimit; offset++) {
+                                var record = {
+                                    appName: {
+                                        value: apps[offset].name
+                                    },
+                                    appSort: {
+                                        value: offset
+                                    },
+                                    appID: {
+                                        value: apps[offset].appId
+                                    },
+                                    parentFolderID: {
+                                        value: 'j1_1'
+                                    }
+                                };
+                                insRecords.push(record);
                             }
-                        });
-                    }
-                    var appIndex = "アプリ一覧";
-                    if (config.lang === "zh") {
-                        appIndex = "软件连接一览";
-                    } else if (config.lang === "en") {
-                        appIndex = "app index";
-                    }
-                    data = [{
-                        text: appIndex,
-                        class: "jstree-open",
-                        children: children,
-                        type: 'root'
-                    }];
-
-                    var recCount = apps.length;
-                    var putCount = Math.ceil(recCount / 100);
-                    for (var k = 0; k < putCount; k++) {
-                        var offset = k * 100;
-                        var limit = 100;
-                        if (offset + limit > recCount) {
-                            limit = recCount - offset;
-                        }
-                        var putLimit = limit + offset;
-                        var insRecords = [];
-
-                        for (offset; offset < putLimit; offset++) {
-                            var record = {
-                                appName: {
-                                    value: apps[offset].name
+                            var finFlg = false;
+                            var finRecs = [];
+                            var rootRecord = {
+                                folderName: {
+                                    value: appIndex
                                 },
-                                appSort: {
-                                    value: offset
-                                },
-                                appID: {
-                                    value: apps[offset].appId
-                                },
-                                parentFolderID: {
-                                    value: "j1_1"
+                                selfFolderID: {
+                                    value: 'j1_1'
                                 }
                             };
-                            insRecords.push(record);
-                        }
-                        var finFlg = false;
-                        var finRecs = [];
-                        var rootRecord = {
-                            folderName: {
-                                value: appIndex
-                            },
-                            selfFolderID: {
-                                value: "j1_1"
+                            if (recCount === offset && (offset % 100) !== 0) {
+                                insRecords.push(rootRecord);
+                                finFlg = true;
+                            } else if (recCount === offset && (offset % 100) === 0) {
+                                finRecs.push(rootRecord);
+                                kintone.api('/k/v1/records', 'POST', {
+                                    app: event.appId,
+                                    records: insRecords
+                                },
+                                function(resp) {
+                                    finFlg = true;
+                                });
                             }
-                        };
-                        if (recCount === offset && (offset % 100) !== 0) {
-                            insRecords.push(rootRecord);
-                            finFlg = true;
-                        } else if (recCount === offset && (offset % 100) === 0) {
-                            finRecs.push(rootRecord);
+
                             kintone.api('/k/v1/records', 'POST', {
                                 app: event.appId,
                                 records: insRecords
                             },
                             function(resp) {
-                                finFlg = true;
-                            });
-                        }
-
-                        kintone.api('/k/v1/records', 'POST', {
-                            app: event.appId,
-                            records: insRecords
-                        },
-                            function(resp) {
                                 if (finFlg) {
                                     location.reload();
                                 }
                             }
-                        );
-                    }
+                            );
+                        }
+                    });
+                }
+
+                d2.promise().then(function() {
+                    createTree(event);
                 });
-            }
 
-            d2.promise().then(function() {
-                createTree(event);
             });
-
-        });
     }
 
     // jstree描画関数
     function createTree(event) {
         $('#tree').jstree({
             core: {
-                "multiple" : false,
+                'multiple': false,
+                // eslint-disable-next-line camelcase
                 'check_callback': true,
                 'themes': {
-                    "variant": "large"
+                    'variant': 'large'
                 },
                 data: data
             },
-            "contextmenu": {
-                "items": function() {
-                    var conLabelRename = "表示名変更";
-                    var conLabelDelete = "一覧から削除";
-                    if (config.lang === "zh") {
-                        conLabelRename = "变更表示名";
-                        conLabelDelete = "删除";
-                    } else if (config.lang === "en") {
-                        conLabelRename = "Change name";
-                        conLabelDelete = "Delete Node";
+            'contextmenu': {
+                'items': function() {
+                    var conLabelRename = '表示名変更';
+                    var conLabelDelete = '一覧から削除';
+                    if (config.lang === 'zh') {
+                        conLabelRename = '变更表示名';
+                        conLabelDelete = '删除';
+                    } else if (config.lang === 'en') {
+                        conLabelRename = 'Change name';
+                        conLabelDelete = 'Delete Node';
                     }
                     return {
-                        "Rename": {
-                            "label": conLabelRename,
-                            "action": function(nameData) {
+                        'Rename': {
+                            'label': conLabelRename,
+                            'action': function(nameData) {
                                 var inst = $.jstree.reference(nameData.reference);
                                 var obj = inst.get_node(nameData.reference);
                                 inst.edit(obj);
                             }
                         },
-                        "Delete": {
-                            "label": conLabelDelete,
-                            "action": function(deleteData) {
+                        'Delete': {
+                            'label': conLabelDelete,
+                            'action': function(deleteData) {
                                 var ref = $.jstree.reference(deleteData.reference),
                                     sel = ref.get_selected();
                                 if (!sel.length) {
@@ -445,6 +447,7 @@ jQuery.noConflict();
                     };
                 }
             },
+            // eslint-disable-next-line camelcase
             check_callback: function(operation, node, node_parent, node_position, more) {
                 switch (operation) {
                     case 'create_node':
@@ -455,18 +458,18 @@ jQuery.noConflict();
             },
             types: {
                 '#': {
-                    valid_children: []
+                    validChildren: []
                 },
                 'default': {
-                    valid_children: []
+                    validChildren: []
                 },
                 folder: {
                     icon: 'jstree-folder',
-                    valid_children: [config.appIcon]
+                    validChildren: [config.appIcon]
                 },
                 file: {
                     icon: 'jstree-file',
-                    valid_children: []
+                    validChildren: []
                 },
                 tree: {
                     icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAA' +
@@ -485,43 +488,43 @@ jQuery.noConflict();
                     'vQlRZjWzqyuJogWJKrE749BZuTtI2lEdg/X/BNG7vTYEGDp7CE5uF8TC8f0' +
                     'nj+SH8K32VNcReMT6nG4/qlveYg2np7sjn1HWFQEb+B/hThmHrrBl4F+akb' +
                     'jmLeHCl/28Ig0BcPhKKzAAAAABJRU5ErkJggg==',
-                    valid_children: config.appIcon !== "tree" ? [config.appIcon] : []
+                    validChildren: config.appIcon !== 'tree' ? [config.appIcon] : []
                 },
                 leaf: {
-                    icon: "glyphicon glyphicon-leaf",
-                    valid_children: config.appIcon !== "leaf" ? [config.appIcon] : []
+                    icon: 'glyphicon glyphicon-leaf',
+                    validChildren: config.appIcon !== 'leaf' ? [config.appIcon] : []
                 },
                 home: {
-                    icon: "glyphicon glyphicon-home",
-                    valid_children: config.appIcon !== "home" ? [config.appIcon] : []
+                    icon: 'glyphicon glyphicon-home',
+                    validChildren: config.appIcon !== 'home' ? [config.appIcon] : []
                 },
                 arrowRight: {
-                    icon: "glyphicon glyphicon-arrow-right",
-                    valid_children: config.appIcon !== "arrowRight" ? [config.appIcon] : []
+                    icon: 'glyphicon glyphicon-arrow-right',
+                    validChildren: config.appIcon !== 'arrowRight' ? [config.appIcon] : []
                 },
                 asterisk: {
-                    icon: "glyphicon glyphicon-asterisk",
-                    valid_children: config.appIcon !== "asterisk" ? [config.appIcon] : []
+                    icon: 'glyphicon glyphicon-asterisk',
+                    validChildren: config.appIcon !== 'asterisk' ? [config.appIcon] : []
                 },
                 bell: {
-                    icon: "glyphicon glyphicon-bell",
-                    valid_children: config.appIcon !== "bell" ? [config.appIcon] : []
+                    icon: 'glyphicon glyphicon-bell',
+                    validChildren: config.appIcon !== 'bell' ? [config.appIcon] : []
                 },
                 handRight: {
-                    icon: "glyphicon glyphicon-hand-right",
-                    valid_children: config.appIcon !== "handRight" ? [config.appIcon] : []
+                    icon: 'glyphicon glyphicon-hand-right',
+                    validChildren: config.appIcon !== 'handRight' ? [config.appIcon] : []
                 },
                 heart: {
-                    icon: "glyphicon glyphicon-heart",
-                    valid_children: config.appIcon !== "heart" ? [config.appIcon] : []
+                    icon: 'glyphicon glyphicon-heart',
+                    validChildren: config.appIcon !== 'heart' ? [config.appIcon] : []
                 },
                 heartEmpty: {
-                    icon: "glyphicon glyphicon-heart-empty",
-                    valid_children: config.appIcon !== "heartEmpty" ? [config.appIcon] : []
+                    icon: 'glyphicon glyphicon-heart-empty',
+                    validChildren: config.appIcon !== 'heartEmpty' ? [config.appIcon] : []
                 },
                 root: {
                     icon: rootIcon,
-                    valid_children: vc_type
+                    validChildren: vcType
                 }
             },
             plugins: [
@@ -529,166 +532,166 @@ jQuery.noConflict();
             ]
         })
             // ローディング終了時、すべてのフォルダを開いた状態にする
-            .bind("loaded.jstree", function() {
-                $(this).jstree("open_all");
+            .bind('loaded.jstree', function() {
+                $(this).jstree('open_all');
                 removeLoading();
                 onceFlg = true;
             })
             // ノードを選択時、設定したURLに飛ばす
-            .bind("select_node.jstree", function(e, s_data) {
+            .bind('select_node.jstree', function(e, sData) {
                 // ただし右クリック時は飛ばさない
                 var evt = window.event || event;
                 var button = evt.which || evt.button;
 
-                if (button !== 1 && (typeof button !== "undefined")) {
+                if (button !== 1 && (typeof button !== 'undefined')) {
                     return false;
                 }
-                if (typeof (s_data.node.original.attr) !== 'undefined') {
-                    var href = s_data.node.original.attr.href;
+                if (typeof (sData.node.original.attr) !== 'undefined') {
+                    var href = sData.node.original.attr.href;
                     window.open(href);
                 }
             })
-            .bind("create_node.jstree", function(c_event, c_obj) {
+            .bind('create_node.jstree', function(cEvent, cObj) {
                 if (onceFlg) {
                     setLoading();
                     onceFlg = false;
                     fetchRecords(event.appId, creator + ' in ("' + kintone.getLoginUser().code + '")' +
                     ' and selfFolderID != "j1_1" order by appSort asc')
-                    .then(function(createRec) {
-                        if (createRec.length > 0) {
-                            var recCount = createRec.length;
-                            var putCount = Math.ceil(recCount / 100);
-                            for (var i = 0; i < putCount; i++) {
-                                var offset = i * 100;
-                                var limit = 100;
-                                if (offset + limit > recCount) {
-                                    limit = recCount - offset;
-                                }
-                                var putLimit = limit + offset;
+                        .then(function(createRec) {
+                            if (createRec.length > 0) {
+                                var recCount = createRec.length;
+                                var putCount = Math.ceil(recCount / 100);
+                                for (var i = 0; i < putCount; i++) {
+                                    var offset = i * 100;
+                                    var limit = 100;
+                                    if (offset + limit > recCount) {
+                                        limit = recCount - offset;
+                                    }
+                                    var putLimit = limit + offset;
 
-                                var editRecords = [];
+                                    var editRecords = [];
 
-                                // 更新対象レコードに更新後のデータを上書き
-                                for (offset; offset < putLimit; offset++) {
-                                    var record = $.extend(true, {}, createRec[offset]);
-                                    var recNo = record['$id'].value;
-                                    delete record['$id'];
-                                    delete record['$revision'];
-                                    delete record[recordNumber];
-                                    delete record[createTime];
-                                    delete record[creator];
-                                    delete record[updateTime];
-                                    delete record[updator];
-                                    record['appSort'].value = parseInt(record['appSort'].value, 10) + 1;
-                                    editRecords.push({
-                                        'id': recNo,
-                                        'record': record
-                                    });
-                                }
-                                var finCnt = -1;
-                                if (recCount === offset) {
-                                    finCnt = limit;
-                                }
-
-                                // 最後に更新処理
-                                kintone.api('/k/v1/records', 'PUT', {
-                                    app: kintone.app.getId(),
-                                    'records': editRecords
-                                }, function(createMoveResp) {
-                                    if (finCnt !== -1 && finCnt === createMoveResp.records.length) {
-                                    // その後新規フォルダレコード作成
-                                        var newFolder = "新規フォルダ";
-                                        if (config.lang === "zh") {
-                                            newFolder = "新规文件夹";
-                                        } else if (config.lang === "en") {
-                                            newFolder = "New folder";
-                                        }
-                                        var postRec = {
-                                            folderName: {
-                                                value: newFolder
-                                            },
-                                            appSort: {
-                                                value: 0
-                                            },
-                                            parentFolderID: {
-                                                value: "j1_1"
-                                            },
-                                            selfFolderID: {
-                                                value: c_event.timeStamp
-                                            }
-                                        };
-                                        kintone.api(kintone.api.url('/k/v1/record', true), 'POST', {
-                                            app: kintone.app.getId(),
-                                            record: postRec
-                                        }, function(createResp) {
-                                            readyTree(event);
+                                    // 更新対象レコードに更新後のデータを上書き
+                                    for (offset; offset < putLimit; offset++) {
+                                        var record = $.extend(true, {}, createRec[offset]);
+                                        var recNo = record['$id'].value;
+                                        delete record['$id'];
+                                        delete record['$revision'];
+                                        delete record[recordNumber];
+                                        delete record[createTime];
+                                        delete record[creator];
+                                        delete record[updateTime];
+                                        delete record[updator];
+                                        record['appSort'].value = parseInt(record['appSort'].value, 10) + 1;
+                                        editRecords.push({
+                                            'id': recNo,
+                                            'record': record
                                         });
                                     }
+                                    var finCnt = -1;
+                                    if (recCount === offset) {
+                                        finCnt = limit;
+                                    }
+
+                                    // 最後に更新処理
+                                    kintone.api('/k/v1/records', 'PUT', {
+                                        app: kintone.app.getId(),
+                                        'records': editRecords
+                                    }, function(createMoveResp) {
+                                        if (finCnt !== -1 && finCnt === createMoveResp.records.length) {
+                                            // その後新規フォルダレコード作成
+                                            var newFolder = '新規フォルダ';
+                                            if (config.lang === 'zh') {
+                                                newFolder = '新规文件夹';
+                                            } else if (config.lang === 'en') {
+                                                newFolder = 'New folder';
+                                            }
+                                            var postRec = {
+                                                folderName: {
+                                                    value: newFolder
+                                                },
+                                                appSort: {
+                                                    value: 0
+                                                },
+                                                parentFolderID: {
+                                                    value: 'j1_1'
+                                                },
+                                                selfFolderID: {
+                                                    value: cEvent.timeStamp
+                                                }
+                                            };
+                                            kintone.api(kintone.api.url('/k/v1/record', true), 'POST', {
+                                                app: kintone.app.getId(),
+                                                record: postRec
+                                            }, function(createResp) {
+                                                readyTree(event);
+                                            });
+                                        }
+                                    });
+                                }
+                            } else {
+                                var newFolder = '新規フォルダ';
+                                if (config.lang === 'zh') {
+                                    newFolder = '新规文件夹';
+                                } else if (config.lang === 'en') {
+                                    newFolder = 'New folder';
+                                }
+                                var postRec = {
+                                    folderName: {
+                                        value: newFolder
+                                    },
+                                    appSort: {
+                                        value: 0
+                                    },
+                                    parentFolderID: {
+                                        value: 'j1_1'
+                                    },
+                                    selfFolderID: {
+                                        value: cEvent.timeStamp
+                                    }
+                                };
+                                kintone.api(kintone.api.url('/k/v1/record', true), 'POST', {
+                                    app: kintone.app.getId(),
+                                    record: postRec
+                                }, function(createResp) {
+                                    readyTree(event);
                                 });
                             }
-                        } else {
-                            var newFolder = "新規フォルダ";
-                            if (config.lang === "zh") {
-                                newFolder = "新规文件夹";
-                            } else if (config.lang === "en") {
-                                newFolder = "New folder";
-                            }
-                            var postRec = {
-                                folderName: {
-                                    value: newFolder
-                                },
-                                appSort: {
-                                    value: 0
-                                },
-                                parentFolderID: {
-                                    value: "j1_1"
-                                },
-                                selfFolderID: {
-                                    value: c_event.timeStamp
-                                }
-                            };
-                            kintone.api(kintone.api.url('/k/v1/record', true), 'POST', {
-                                app: kintone.app.getId(),
-                                record: postRec
-                            }, function(createResp) {
-                                readyTree(event);
-                            });
-                        }
-                    });
+                        });
                 }
             })
-            .bind("rename_node.jstree", function(r_event, r_obj) {
+            .bind('rename_node.jstree', function(rEvent, rObj) {
                 setLoading();
                 var appFolder;
                 var appFlg = true;
                 // フォルダの場合
-                if (r_obj.node.type === config.folderIcon || r_obj.node.type === "root") {
+                if (rObj.node.type === config.folderIcon || rObj.node.type === 'root') {
                     appFolder = creator + ' in ("' + kintone.getLoginUser().code + '") and selfFolderID = "' +
-                    r_obj.node.original.self + '"';
+                    rObj.node.original.self + '"';
                     appFlg = false;
                 } else {
                     appFolder = creator + ' in ("' + kintone.getLoginUser().code +
-                    '") and appID = "' + r_obj.node.original.appId + '"';
+                    '") and appID = "' + rObj.node.original.appId + '"';
                 }
                 fetchRecords(event.appId, appFolder).then(function(renamePutRec) {
                     var body;
                     if (appFlg) {
                         body = {
-                            "app": kintone.app.getId(),
-                            "id": renamePutRec[0][recordNumber].value,
-                            "record": {
-                                "appName": {
-                                    "value": r_obj.text
+                            'app': kintone.app.getId(),
+                            'id': renamePutRec[0][recordNumber].value,
+                            'record': {
+                                'appName': {
+                                    'value': rObj.text
                                 }
                             }
                         };
                     } else {
                         body = {
-                            "app": kintone.app.getId(),
-                            "id": renamePutRec[0][recordNumber].value,
-                            "record": {
-                                "folderName": {
-                                    "value": r_obj.text
+                            'app': kintone.app.getId(),
+                            'id': renamePutRec[0][recordNumber].value,
+                            'record': {
+                                'folderName': {
+                                    'value': rObj.text
                                 }
                             }
                         };
@@ -699,174 +702,174 @@ jQuery.noConflict();
                 });
 
             })
-            .bind("delete_node.jstree", function(d_event, d_obj) {
+            .bind('delete_node.jstree', function(dEvent, dObj) {
                 setLoading();
                 // ルートの場合
-                if (d_obj.node.type === "root") {
+                if (dObj.node.type === 'root') {
                     swal({
-                        title: "ルートフォルダは削除できません。",
+                        title: 'ルートフォルダは削除できません。',
                         type: 'error'
                     }, function(ok) {
                         readyTree(event);
                     });
-                } else if (d_obj.node.type === config.folderIcon) { // フォルダの場合
+                } else if (dObj.node.type === config.folderIcon) { // フォルダの場合
                     fetchRecords(kintone.app.getId(), creator + ' in ("' + kintone.getLoginUser().code +
-                    '") and appSort >= "' + d_obj.node.original.appSort + '" order by appSort asc')
-                    .then(function(deleteFolder) {
-                        var delFolderId = [deleteFolder[0].$id.value];
-                        for (var dfkey in deleteFolder) {
-                            if (deleteFolder[dfkey].parentFolderID.value === d_obj.node.original.self) {
-                                delFolderId.push(deleteFolder[dfkey].$id.value);
+                    '") and appSort >= "' + dObj.node.original.appSort + '" order by appSort asc')
+                        .then(function(deleteFolder) {
+                            var delFolderId = [deleteFolder[0].$id.value];
+                            for (var dfkey in deleteFolder) {
+                                if (deleteFolder[dfkey].parentFolderID.value === dObj.node.original.self) {
+                                    delFolderId.push(deleteFolder[dfkey].$id.value);
+                                }
                             }
-                        }
-                        deleteRecords(kintone.app.getId(), delFolderId).then(function() {
-                            if (deleteFolder.length > delFolderId.length) {
-                                deleteFolder.splice(0, delFolderId.length);
-                                var recCount = deleteFolder.length;
-                                var putCount = Math.ceil(recCount / 100);
-                                for (var i = 0; i < putCount; i++) {
-                                    var offset = i * 100;
-                                    var limit = 100;
-                                    if (offset + limit > recCount) {
-                                        limit = recCount - offset;
-                                    }
-                                    var putLimit = limit + offset;
+                            deleteRecords(kintone.app.getId(), delFolderId).then(function() {
+                                if (deleteFolder.length > delFolderId.length) {
+                                    deleteFolder.splice(0, delFolderId.length);
+                                    var recCount = deleteFolder.length;
+                                    var putCount = Math.ceil(recCount / 100);
+                                    for (var i = 0; i < putCount; i++) {
+                                        var offset = i * 100;
+                                        var limit = 100;
+                                        if (offset + limit > recCount) {
+                                            limit = recCount - offset;
+                                        }
+                                        var putLimit = limit + offset;
 
-                                    var editRecords = [];
+                                        var editRecords = [];
 
-                                    // 更新対象レコードに更新後のデータを上書き
-                                    for (offset; offset < putLimit; offset++) {
-                                        var record = $.extend(true, {}, deleteFolder[offset]);
-                                        var recNo = record['$id'].value;
-                                        delete record['$id'];
-                                        delete record['$revision'];
-                                        delete record[recordNumber];
-                                        delete record[createTime];
-                                        delete record[creator];
-                                        delete record[updateTime];
-                                        delete record[updator];
-                                        record['appSort'].value = parseInt(record['appSort'].value, 10) -
+                                        // 更新対象レコードに更新後のデータを上書き
+                                        for (offset; offset < putLimit; offset++) {
+                                            var record = $.extend(true, {}, deleteFolder[offset]);
+                                            var recNo = record['$id'].value;
+                                            delete record['$id'];
+                                            delete record['$revision'];
+                                            delete record[recordNumber];
+                                            delete record[createTime];
+                                            delete record[creator];
+                                            delete record[updateTime];
+                                            delete record[updator];
+                                            record['appSort'].value = parseInt(record['appSort'].value, 10) -
                                         delFolderId.length;
-                                        editRecords.push({
-                                            'id': recNo,
-                                            'record': record
+                                            editRecords.push({
+                                                'id': recNo,
+                                                'record': record
+                                            });
+                                        }
+
+                                        var finCnt = -1;
+                                        if (recCount === offset) {
+                                            finCnt = limit;
+                                        }
+
+                                        // 最後に更新処理
+                                        kintone.api('/k/v1/records', 'PUT', {
+                                            app: kintone.app.getId(),
+                                            'records': editRecords
+                                        }, function(moveUpResp) {
+                                            if (finCnt !== -1 && finCnt === moveUpResp.records.length) {
+                                                readyTree(event);
+                                            }
                                         });
                                     }
-
-                                    var finCnt = -1;
-                                    if (recCount === offset) {
-                                        finCnt = limit;
-                                    }
-
-                                    // 最後に更新処理
-                                    kintone.api('/k/v1/records', 'PUT', {
-                                        app: kintone.app.getId(),
-                                        'records': editRecords
-                                    }, function(moveUpResp) {
-                                        if (finCnt !== -1 && finCnt === moveUpResp.records.length) {
-                                            readyTree(event);
-                                        }
-                                    });
+                                } else {
+                                    readyTree(event);
                                 }
-                            } else {
-                                readyTree(event);
-                            }
-                        });
+                            });
 
-                    });
+                        });
                 } else { // アプリの場合
                     fetchRecords(kintone.app.getId(), creator + ' in ("' + kintone.getLoginUser().code +
-                    '") and appSort >= "' + d_obj.node.original.appSort + '" order by appSort asc')
-                    .then(function(deleteApp) {
-                        var delAppId = [deleteApp[0].$id.value];
-                        deleteRecords(kintone.app.getId(), delAppId).then(function() {
-                            if (deleteApp.length > 1) {
-                                deleteApp.splice(0, 1);
-                                var recCount = deleteApp.length;
-                                var putCount = Math.ceil(recCount / 100);
-                                for (var i = 0; i < putCount; i++) {
-                                    var offset = i * 100;
-                                    var limit = 100;
-                                    if (offset + limit > recCount) {
-                                        limit = recCount - offset;
-                                    }
-                                    var putLimit = limit + offset;
+                    '") and appSort >= "' + dObj.node.original.appSort + '" order by appSort asc')
+                        .then(function(deleteApp) {
+                            var delAppId = [deleteApp[0].$id.value];
+                            deleteRecords(kintone.app.getId(), delAppId).then(function() {
+                                if (deleteApp.length > 1) {
+                                    deleteApp.splice(0, 1);
+                                    var recCount = deleteApp.length;
+                                    var putCount = Math.ceil(recCount / 100);
+                                    for (var i = 0; i < putCount; i++) {
+                                        var offset = i * 100;
+                                        var limit = 100;
+                                        if (offset + limit > recCount) {
+                                            limit = recCount - offset;
+                                        }
+                                        var putLimit = limit + offset;
 
-                                    var editRecords = [];
+                                        var editRecords = [];
 
-                                    // 更新対象レコードに更新後のデータを上書き
-                                    for (offset; offset < putLimit; offset++) {
-                                        var record = $.extend(true, {}, deleteApp[offset]);
-                                        var recNo = record['$id'].value;
-                                        delete record['$id'];
-                                        delete record['$revision'];
-                                        delete record[recordNumber];
-                                        delete record[createTime];
-                                        delete record[creator];
-                                        delete record[updateTime];
-                                        delete record[updator];
-                                        record['appSort'].value = parseInt(record['appSort'].value, 10) - 1;
-                                        editRecords.push({
-                                            'id': recNo,
-                                            'record': record
+                                        // 更新対象レコードに更新後のデータを上書き
+                                        for (offset; offset < putLimit; offset++) {
+                                            var record = $.extend(true, {}, deleteApp[offset]);
+                                            var recNo = record['$id'].value;
+                                            delete record['$id'];
+                                            delete record['$revision'];
+                                            delete record[recordNumber];
+                                            delete record[createTime];
+                                            delete record[creator];
+                                            delete record[updateTime];
+                                            delete record[updator];
+                                            record['appSort'].value = parseInt(record['appSort'].value, 10) - 1;
+                                            editRecords.push({
+                                                'id': recNo,
+                                                'record': record
+                                            });
+                                        }
+
+                                        var finCnt = -1;
+                                        if (recCount === offset) {
+                                            finCnt = limit;
+                                        }
+
+                                        // 最後に更新処理
+                                        kintone.api('/k/v1/records', 'PUT', {
+                                            app: kintone.app.getId(),
+                                            'records': editRecords
+                                        }, function(moveUpResp) {
+                                            if (finCnt !== -1 && finCnt === moveUpResp.records.length) {
+                                                readyTree(event);
+                                            }
                                         });
                                     }
-
-                                    var finCnt = -1;
-                                    if (recCount === offset) {
-                                        finCnt = limit;
-                                    }
-
-                                    // 最後に更新処理
-                                    kintone.api('/k/v1/records', 'PUT', {
-                                        app: kintone.app.getId(),
-                                        'records': editRecords
-                                    }, function(moveUpResp) {
-                                        if (finCnt !== -1 && finCnt === moveUpResp.records.length) {
-                                            readyTree(event);
-                                        }
-                                    });
+                                } else {
+                                    readyTree(event);
                                 }
-                            } else {
-                                readyTree(event);
-                            }
+                            });
                         });
-                    });
                 }
 
             })
-            .bind("move_node.jstree", function(m_event, m_obj) {
+            .bind('move_node.jstree', function(mEvent, mObj) {
                 setLoading();
                 // 同じフォルダ内で移動した場合
-                if (m_obj.old_parent === m_obj.parent) {
+                if (mObj.old_parent === mObj.parent) {
                     var fetchQuery;
                     var folderWithAppFlg = false;
                     // フォルダの場合
-                    if (m_obj.node.type === config.folderIcon) {
+                    if (mObj.node.type === config.folderIcon) {
                         fetchQuery = creator + ' in ("' + kintone.getLoginUser().code +
-                        '") and selfFolderID = "' + m_obj.node.original.self + '"';
+                        '") and selfFolderID = "' + mObj.node.original.self + '"';
                         // 移動対象がアプリの紐づくフォルダかどうか
-                        if (m_obj.node.children.length > 0) {
+                        if (mObj.node.children.length > 0) {
                             folderWithAppFlg = true;
                         }
                     } else {
                         fetchQuery = creator + ' in ("' + kintone.getLoginUser().code +
-                        '") and appID = "' + m_obj.node.original.appId + '"';
+                        '") and appID = "' + mObj.node.original.appId + '"';
                     }
                     fetchRecords(event.appId, fetchQuery).then(function(movePutRec) {
-                        var moveNum = m_obj.position - m_obj.old_position;
+                        var moveNum = mObj.position - mObj.old_position;
                         var positionCount = 0;
-                        var currentPosition = m_obj.position;
-                        var oldPosition = m_obj.old_position;
+                        var currentPosition = mObj.position;
+                        var oldPosition = mObj.old_position;
                         // 上に移動
                         if (moveNum < 0) {
-                            if (m_obj.parent.indexOf("_1") > 0) {
+                            if (mObj.parent.indexOf('_1') > 0) {
                             // 現在ポジションまでにフォルダがあるか
                                 for (var ikey in folderInfo) {
                                     for (var m = currentPosition; m < oldPosition; m++) {
                                         if (m === parseInt(ikey, 10)) {
                                             if (folderWithAppFlg && folderInfo[ikey].length > 0 &&
-                                                folderInfo[ikey][0].parentFolderID !== m_obj.node.original.self) {
+                                                folderInfo[ikey][0].parentFolderID !== mObj.node.original.self) {
                                                 positionCount = folderInfo[ikey].length;
                                                 moveNum -= positionCount;
                                                 break;
@@ -879,15 +882,13 @@ jQuery.noConflict();
                                     }
                                 }
                             }
-                        } else {
-                            if (m_obj.parent.indexOf("_1") > 0) {
-                                for (var ikey2 in folderInfo) {
-                                    for (var m2 = oldPosition + 1; m2 < currentPosition + 1; m2++) {
-                                        if (m2 === parseInt(ikey2, 10)) {
-                                            positionCount = folderInfo[ikey2].length;
-                                            moveNum += positionCount;
-                                            break;
-                                        }
+                        } else if (mObj.parent.indexOf('_1') > 0) {
+                            for (var ikey2 in folderInfo) {
+                                for (var m2 = oldPosition + 1; m2 < currentPosition + 1; m2++) {
+                                    if (m2 === parseInt(ikey2, 10)) {
+                                        positionCount = folderInfo[ikey2].length;
+                                        moveNum += positionCount;
+                                        break;
                                     }
                                 }
                             }
@@ -896,11 +897,11 @@ jQuery.noConflict();
                         var movedRecId = movePutRec[0][recordNumber].value;
                         var movedSortValue = parseInt(movePutRec[0].appSort.value, 10) + moveNum;
                         var moveBody = {
-                            "app": kintone.app.getId(),
-                            "id": movedRecId,
-                            "record": {
-                                "appSort": {
-                                    "value": movedSortValue
+                            'app': kintone.app.getId(),
+                            'id': movedRecId,
+                            'record': {
+                                'appSort': {
+                                    'value': movedSortValue
                                 }
                             }
                         };
@@ -911,13 +912,13 @@ jQuery.noConflict();
                                 if (folderWithAppFlg) {
                                     moveQuery = creator + ' in ("' + kintone.getLoginUser().code +
                                     '") and appSort >= "' + movedSortValue + '" and appSort <= "' +
-                                    (parseInt(movePutRec[0].appSort.value, 10) + m_obj.node.children.length) +
+                                    (parseInt(movePutRec[0].appSort.value, 10) + mObj.node.children.length) +
                                     '" and ' + recordNumber + ' != "' + movedRecId + '" order by appSort asc';
                                 } else if (positionCount === 0) {
                                     moveQuery = creator + ' in ("' + kintone.getLoginUser().code +
                                     '") and appSort >= "' + movedSortValue + '" and appSort < "' +
                                     movePutRec[0].appSort.value + '" and ' + recordNumber + ' != "' + movedRecId +
-                                    '" and parentFolderID = "' + m_obj.node.original.parentFolderID + '"';
+                                    '" and parentFolderID = "' + mObj.node.original.parentFolderID + '"';
                                 } else {
                                     moveQuery = creator + ' in ("' + kintone.getLoginUser().code +
                                     '") and appSort >= "' + movedSortValue + '" and appSort < "' +
@@ -927,13 +928,13 @@ jQuery.noConflict();
                                     if (folderWithAppFlg) {
                                         var appSortCnt = movedSortValue;
                                         for (var q = 0; q < movePutOtherRecs.length; q++) {
-                                            if (movePutOtherRecs[q].parentFolderID.value === m_obj.node.original.self) {
+                                            if (movePutOtherRecs[q].parentFolderID.value === mObj.node.original.self) {
                                                 movePutOtherRecs[q].appSort.value = appSortCnt;
                                                 appSortCnt++;
                                             } else {
                                                 movePutOtherRecs[q].appSort.value =
                                                 parseInt(movePutOtherRecs[q].appSort.value, 10) +
-                                                m_obj.node.children.length;
+                                                mObj.node.children.length;
                                             }
                                         }
                                     }
@@ -991,18 +992,18 @@ jQuery.noConflict();
                                 var moveQuery2;
                                 if (folderWithAppFlg) {
                                     moveQuery2 = creator + ' in ("' + kintone.getLoginUser().code +
-                                    '") and appSort <= "' + (movedSortValue + m_obj.node.children.length) +
-                                    '" and appSort >= "' + m_obj.node.original.appSort +
+                                    '") and appSort <= "' + (movedSortValue + mObj.node.children.length) +
+                                    '" and appSort >= "' + mObj.node.original.appSort +
                                     '" and ' + recordNumber + ' != "' + movedRecId + '" order by appSort asc';
                                 } else if (positionCount === 0) {
                                     moveQuery2 = creator + ' in ("' + kintone.getLoginUser().code +
                                     '") and appSort <= "' + movedSortValue + '" and appSort > "' +
-                                    m_obj.node.original.appSort + '" and ' + recordNumber + ' != "' +
-                                    movedRecId + '" and parentFolderID = "' + m_obj.node.original.parentFolderID + '"';
+                                    mObj.node.original.appSort + '" and ' + recordNumber + ' != "' +
+                                    movedRecId + '" and parentFolderID = "' + mObj.node.original.parentFolderID + '"';
                                 } else {
                                     moveQuery2 = creator + ' in ("' + kintone.getLoginUser().code +
                                     '") and appSort <= "' + movedSortValue + '" and appSort > "' +
-                                    m_obj.node.original.appSort + '" and ' + recordNumber + ' != "' + movedRecId + '"';
+                                    mObj.node.original.appSort + '" and ' + recordNumber + ' != "' + movedRecId + '"';
                                 }
                                 fetchRecords(event.appId, moveQuery2).then(function(movePutOtherRecs) {
                                     if (movePutOtherRecs.length > 0) {
@@ -1010,13 +1011,13 @@ jQuery.noConflict();
                                             var appSortCnt = movedSortValue;
                                             for (var q = 0; q < movePutOtherRecs.length; q++) {
                                                 if (movePutOtherRecs[q].parentFolderID.value ===
-                                                m_obj.node.original.self) {
+                                                mObj.node.original.self) {
                                                     movePutOtherRecs[q].appSort.value = (appSortCnt + 2);
                                                     appSortCnt++;
                                                 } else {
                                                     movePutOtherRecs[q].appSort.value =
                                                     parseInt(movePutOtherRecs[q].appSort.value, 10) -
-                                                    m_obj.node.children.length;
+                                                    mObj.node.children.length;
                                                 }
                                             }
                                         }
@@ -1074,9 +1075,9 @@ jQuery.noConflict();
                         });
                     });
                 } else { // 別フォルダに移動させた場合
-                    var parentSortNum = m_obj.parent.split("_");
-                    if (parentSortNum[1] === "1") {
-                        parentSortNum = "";
+                    var parentSortNum = mObj.parent.split('_');
+                    if (parentSortNum[1] === '1') {
+                        parentSortNum = '';
                     } else {
                         parentSortNum = parseInt(parentSortNum[1], 10) - 2;
                     }
@@ -1089,16 +1090,16 @@ jQuery.noConflict();
                         var chNodeCnt2 = 0;
                         // 下へ移動した場合
                         if (parseInt(moveOtherFolderParentRec[0].appSort.value, 10) >
-                        parseInt(m_obj.node.original.appSort, 10)) {
+                        parseInt(mObj.node.original.appSort, 10)) {
                             upFlg = false;
-                        } else if (moveOtherFolderParentRec[0].selfFolderID.value === "j1_1") {
+                        } else if (moveOtherFolderParentRec[0].selfFolderID.value === 'j1_1') {
                             for (var ikey3 in folderInfo) {
-                                for (var n = 0; n < m_obj.position; n++) {
+                                for (var n = 0; n < mObj.position; n++) {
                                     if (n === parseInt(ikey3, 10)) {
                                         for (var o = 0; o < folderInfo[ikey3].length; o++) {
                                             if (folderInfo[ikey3][o].parentFolderID ===
-                                            m_obj.node.original.parentFolderID) {
-                                                if (folderInfo[ikey3][o].appSort !== m_obj.node.original.appSort) {
+                                            mObj.node.original.parentFolderID) {
+                                                if (folderInfo[ikey3][o].appSort !== mObj.node.original.appSort) {
                                                     chNodeCnt2++;
                                                 }
                                             } else {
@@ -1110,7 +1111,7 @@ jQuery.noConflict();
                                     }
                                 }
                             }
-                            if (m_obj.position + chNodeCnt2 >= m_obj.node.original.appSort) {
+                            if (mObj.position + chNodeCnt2 >= mObj.node.original.appSort) {
                                 upFlg = false;
                                 folderDownFlg = true;
                             } else {
@@ -1121,15 +1122,15 @@ jQuery.noConflict();
                             upFlg = true;
                         }
                         var fetchQuery2 = creator + ' in ("' + kintone.getLoginUser().code +
-                        '") and appID = "' + m_obj.node.original.appId + '"';
+                        '") and appID = "' + mObj.node.original.appId + '"';
                         fetchRecords(event.appId, fetchQuery2).then(function(moveOtherFolderSelfRec) {
                             var appSortValue;
                             if (upFlg) {
                                 // 作成フォルダからルートフォルダに下から上に移動した場合
-                                if (moveOtherFolderParentRec[0].selfFolderID.value === "j1_1") {
+                                if (moveOtherFolderParentRec[0].selfFolderID.value === 'j1_1') {
                                     var chNodeCnt = 0;
                                     for (var ikey4 in folderInfo) {
-                                        for (var m3 = 0; m3 < m_obj.position; m3++) {
+                                        for (var m3 = 0; m3 < mObj.position; m3++) {
                                             if (m3 === parseInt(ikey4, 10)) {
                                                 chNodeCnt += folderInfo[ikey4].length;
                                                 break;
@@ -1137,186 +1138,186 @@ jQuery.noConflict();
                                         }
                                     }
 
-                                    appSortValue = m_obj.position + chNodeCnt;
+                                    appSortValue = mObj.position + chNodeCnt;
                                 } else {
                                     appSortValue = parseInt(moveOtherFolderParentRec[0].appSort.value, 10) +
-                                    m_obj.position + 1;
+                                    mObj.position + 1;
                                 }
                             } else if (folderDownFlg) {
-                                appSortValue = m_obj.position + chNodeCnt2;
+                                appSortValue = mObj.position + chNodeCnt2;
                             } else {
-                                appSortValue = parseInt(moveOtherFolderParentRec[0].appSort.value, 10) + m_obj.position;
+                                appSortValue = parseInt(moveOtherFolderParentRec[0].appSort.value, 10) + mObj.position;
                             }
                             var movedOtherFolderRecId = moveOtherFolderSelfRec[0][recordNumber].value;
                             var moveOtherFolderBody = {
-                                "app": kintone.app.getId(),
-                                "id": movedOtherFolderRecId,
-                                "record": {
-                                    "appSort": {
-                                        "value": appSortValue
+                                'app': kintone.app.getId(),
+                                'id': movedOtherFolderRecId,
+                                'record': {
+                                    'appSort': {
+                                        'value': appSortValue
                                     },
-                                    "parentFolderID": {
-                                        "value": moveOtherFolderParentRec[0].selfFolderID.value
+                                    'parentFolderID': {
+                                        'value': moveOtherFolderParentRec[0].selfFolderID.value
                                     }
                                 }
                             };
                             kintone.api(kintone.api.url('/k/v1/record', true), 'PUT',
-                            moveOtherFolderBody, function(moveOtherFolderResp) {
+                                moveOtherFolderBody, function(moveOtherFolderResp) {
                                 // 上に移動した場合
-                                if (upFlg) {
-                                    fetchRecords(event.appId, creator + ' in ("' + kintone.getLoginUser().code +
+                                    if (upFlg) {
+                                        fetchRecords(event.appId, creator + ' in ("' + kintone.getLoginUser().code +
                                     '") and appSort >= "' + appSortValue + '" and appSort < "' +
-                                    m_obj.node.original.appSort + '" and ' + recordNumber + ' != "' +
+                                    mObj.node.original.appSort + '" and ' + recordNumber + ' != "' +
                                     movedOtherFolderRecId + '"').then(function(moveOtherFolderRecs) {
-                                        var recCount = moveOtherFolderRecs.length;
-                                        if (recCount !== 0) {
-                                            var putCount = Math.ceil(recCount / 100);
-                                            for (var i = 0; i < putCount; i++) {
-                                                var offset = i * 100;
-                                                var limit = 100;
-                                                if (offset + limit > recCount) {
-                                                    limit = recCount - offset;
-                                                }
-                                                var putLimit = limit + offset;
+                                            var recCount = moveOtherFolderRecs.length;
+                                            if (recCount !== 0) {
+                                                var putCount = Math.ceil(recCount / 100);
+                                                for (var i = 0; i < putCount; i++) {
+                                                    var offset = i * 100;
+                                                    var limit = 100;
+                                                    if (offset + limit > recCount) {
+                                                        limit = recCount - offset;
+                                                    }
+                                                    var putLimit = limit + offset;
 
-                                                var editRecords = [];
+                                                    var editRecords = [];
 
-                                                // 更新対象レコードに更新後のデータを上書き
-                                                for (offset; offset < putLimit; offset++) {
-                                                    var record = $.extend(true, {}, moveOtherFolderRecs[offset]);
-                                                    var recNo = record['$id'].value;
-                                                    delete record['$id'];
-                                                    delete record['$revision'];
-                                                    delete record[recordNumber];
-                                                    delete record[createTime];
-                                                    delete record[creator];
-                                                    delete record[updateTime];
-                                                    delete record[updator];
-                                                    record['appSort'].value = parseInt(record['appSort'].value, 10) + 1;
-                                                    editRecords.push({
-                                                        'id': recNo,
-                                                        'record': record
+                                                    // 更新対象レコードに更新後のデータを上書き
+                                                    for (offset; offset < putLimit; offset++) {
+                                                        var record = $.extend(true, {}, moveOtherFolderRecs[offset]);
+                                                        var recNo = record['$id'].value;
+                                                        delete record['$id'];
+                                                        delete record['$revision'];
+                                                        delete record[recordNumber];
+                                                        delete record[createTime];
+                                                        delete record[creator];
+                                                        delete record[updateTime];
+                                                        delete record[updator];
+                                                        record['appSort'].value = parseInt(record['appSort'].value, 10) + 1;
+                                                        editRecords.push({
+                                                            'id': recNo,
+                                                            'record': record
+                                                        });
+                                                    }
+
+                                                    var finCnt = -1;
+                                                    if (recCount === offset) {
+                                                        finCnt = limit;
+                                                    }
+
+                                                    // 最後に更新処理
+                                                    kintone.api('/k/v1/records', 'PUT', {
+                                                        app: kintone.app.getId(),
+                                                        'records': editRecords
+                                                    }, function(moveUpResp) {
+                                                        if (finCnt !== -1 && finCnt === moveUpResp.records.length) {
+                                                            readyTree(event);
+                                                        }
                                                     });
                                                 }
-
-                                                var finCnt = -1;
-                                                if (recCount === offset) {
-                                                    finCnt = limit;
-                                                }
-
-                                                // 最後に更新処理
-                                                kintone.api('/k/v1/records', 'PUT', {
-                                                    app: kintone.app.getId(),
-                                                    'records': editRecords
-                                                }, function(moveUpResp) {
-                                                    if (finCnt !== -1 && finCnt === moveUpResp.records.length) {
-                                                        readyTree(event);
-                                                    }
-                                                });
+                                            } else {
+                                                readyTree(event);
                                             }
-                                        } else {
-                                            readyTree(event);
-                                        }
-                                    });
-                                } else {
-                                    fetchRecords(event.appId, creator + ' in ("' + kintone.getLoginUser().code +
+                                        });
+                                    } else {
+                                        fetchRecords(event.appId, creator + ' in ("' + kintone.getLoginUser().code +
                                     '") and appSort <= "' + appSortValue + '" and appSort > "' +
-                                    m_obj.node.original.appSort + '" and ' + recordNumber + ' != "' +
+                                    mObj.node.original.appSort + '" and ' + recordNumber + ' != "' +
                                     movedOtherFolderRecId + '"').then(function(movePutOtherFolderRecs) {
-                                        var recCount = movePutOtherFolderRecs.length;
-                                        if (recCount !== 0) {
-                                        var putCount = Math.ceil(recCount / 100);
-                                            for (var i = 0; i < putCount; i++) {
-                                                var offset = i * 100;
-                                                var limit = 100;
-                                                if (offset + limit > recCount) {
-                                                    limit = recCount - offset;
-                                                }
-                                                var putLimit = limit + offset;
+                                            var recCount = movePutOtherFolderRecs.length;
+                                            if (recCount !== 0) {
+                                                var putCount = Math.ceil(recCount / 100);
+                                                for (var i = 0; i < putCount; i++) {
+                                                    var offset = i * 100;
+                                                    var limit = 100;
+                                                    if (offset + limit > recCount) {
+                                                        limit = recCount - offset;
+                                                    }
+                                                    var putLimit = limit + offset;
 
-                                                var editRecords = [];
+                                                    var editRecords = [];
 
-                                                // 更新対象レコードに更新後のデータを上書き
-                                                for (offset; offset < putLimit; offset++) {
-                                                    var record = $.extend(true, {}, movePutOtherFolderRecs[offset]);
-                                                    var recNo = record['$id'].value;
-                                                    delete record['$id'];
-                                                    delete record['$revision'];
-                                                    delete record[recordNumber];
-                                                    delete record[createTime];
-                                                    delete record[creator];
-                                                    delete record[updateTime];
-                                                    delete record[updator];
-                                                    record['appSort'].value = parseInt(record['appSort'].value, 10) - 1;
-                                                    editRecords.push({
-                                                        'id': recNo,
-                                                        'record': record
+                                                    // 更新対象レコードに更新後のデータを上書き
+                                                    for (offset; offset < putLimit; offset++) {
+                                                        var record = $.extend(true, {}, movePutOtherFolderRecs[offset]);
+                                                        var recNo = record['$id'].value;
+                                                        delete record['$id'];
+                                                        delete record['$revision'];
+                                                        delete record[recordNumber];
+                                                        delete record[createTime];
+                                                        delete record[creator];
+                                                        delete record[updateTime];
+                                                        delete record[updator];
+                                                        record['appSort'].value = parseInt(record['appSort'].value, 10) - 1;
+                                                        editRecords.push({
+                                                            'id': recNo,
+                                                            'record': record
+                                                        });
+                                                    }
+
+                                                    var finCnt = -1;
+                                                    if (recCount === offset) {
+                                                        finCnt = limit;
+                                                    }
+
+                                                    // 最後に更新処理
+                                                    kintone.api('/k/v1/records', 'PUT', {
+                                                        app: kintone.app.getId(),
+                                                        'records': editRecords
+                                                    }, function(moveDownResp) {
+                                                        if (finCnt !== -1 && finCnt === moveDownResp.records.length) {
+                                                            readyTree(event);
+                                                        }
                                                     });
                                                 }
-
-                                                var finCnt = -1;
-                                                if (recCount === offset) {
-                                                    finCnt = limit;
-                                                }
-
-                                                // 最後に更新処理
-                                                kintone.api('/k/v1/records', 'PUT', {
-                                                    app: kintone.app.getId(),
-                                                    'records': editRecords
-                                                }, function(moveDownResp) {
-                                                    if (finCnt !== -1 && finCnt === moveDownResp.records.length) {
-                                                        readyTree(event);
-                                                    }
-                                                });
+                                            } else {
+                                                readyTree(event);
                                             }
-                                        } else {
-                                            readyTree(event);
-                                        }
-                                    });
-                                }
-                            });
+                                        });
+                                    }
+                                });
                         });
 
                     });
                 }
-                $(this).jstree("open_all");
+                $(this).jstree('open_all');
             });
         $('#folderCreate').click(function() {
-            $('#tree').jstree("deselect_all");
+            $('#tree').jstree('deselect_all');
             $('#tree').jstree('select_node', 'ul > li:first');
             var ref = $('#tree').jstree(true),
                 sel = ref.get_selected();
             if (!sel.length) {
                 return false;
             }
-            var newFolder = "新規フォルダ";
-            if (config.lang === "zh") {
-                newFolder = "新规文件夹";
-            } else if (config.lang === "en") {
-                newFolder = "New folder";
+            var newFolder = '新規フォルダ';
+            if (config.lang === 'zh') {
+                newFolder = '新规文件夹';
+            } else if (config.lang === 'en') {
+                newFolder = 'New folder';
             }
             sel = sel[0];
             sel = ref.create_node(sel, {
-                "text": newFolder,
-                class: "jstree-open",
-                "type": folderIcon
-            }, "first");
+                'text': newFolder,
+                class: 'jstree-open',
+                'type': folderIcon
+            }, 'first');
             if (sel) {
                 ref.edit(sel);
             }
         });
         $('#returnDefault').click(function() {
-            var title = "一覧をすべて初期化しますか？";
-            var yes = "はい";
-            var no = "いいえ";
-            if (config.lang === "zh"){
-                title = "回复初期状态一览吗？";
-                yes = "是";
-                no = "不";
-            } else if (config.lang === "en") {
-                title = "Reset index?";
-                yes = "YES";
-                no = "NO";
+            var title = '一覧をすべて初期化しますか？';
+            var yes = 'はい';
+            var no = 'いいえ';
+            if (config.lang === 'zh') {
+                title = '回复初期状态一览吗？';
+                yes = '是';
+                no = '不';
+            } else if (config.lang === 'en') {
+                title = 'Reset index?';
+                yes = 'YES';
+                no = 'NO';
             }
             swal({
                 title: title,
@@ -1351,10 +1352,11 @@ jQuery.noConflict();
         }
 
         // アプリ一覧の場合のみpaddingを変更
-        $(".box-gaia").css("padding", "0px 150px");
+        $('.box-gaia').css('padding', '0px 150px');
         readyTree(event);
 
         return event;
     });
 
 })(jQuery, kintone.$PLUGIN_ID);
+

--- a/examples/appIndex/manifest.json
+++ b/examples/appIndex/manifest.json
@@ -35,7 +35,7 @@
         ],
         "css": [
             "css/config.css",
-            "css/51-us-default.css",
+            "css/51-modern-default.css",
             "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
         ],
         "required_params": ["folderIcon", "appIcon"]

--- a/examples/ganttchart/js/desktop-ganttchart.js
+++ b/examples/ganttchart/js/desktop-ganttchart.js
@@ -135,6 +135,7 @@ function removeLoading() {
 }
 
 // ×ボタンでモーダルウィンドウを消すときの処理
+// eslint-disable-next-line no-unused-vars
 function closeButton() {
     'use strict';
     $('#modal').fadeOut(250);
@@ -144,58 +145,6 @@ function closeButton() {
 
 (function($, moment, PLUGIN_ID) {
     'use strict';
-
-    var domFromObject = function(obj, callback) {
-        var i, r;
-        if (['string', 'number'].indexOf(typeof obj) >= 0) {
-            r = obj;
-        } else if (obj instanceof Array) {
-            r = [];
-            for (i = 0; i < obj.length; i++) {
-                r.push(domFromObject(obj[i]));
-            }
-        } else if (obj.constructor === Object) {
-            var tag = obj.tag;
-            var elm = document.createElement(tag);
-            for (i in obj) {
-                if (obj.hasOwnProperty(i)) {
-                    if (callback) {
-                        if (callback(i, elm, obj[i])) {
-                            continue;
-                        }
-                    }
-                    if (i === 'tag') {
-                        continue;
-                    }
-                    var v;
-                    if (i === 'content') {
-                        v = domFromObject(obj[i]);
-                        if (v instanceof Array) {
-                            for (var j = 0; j < v.length; j++) {
-                                var v2;
-                                if (typeof v[j] === 'string') {
-                                    v2 = document.createTextNode(v[j]);
-                                } else {
-                                    v2 = v[j];
-                                }
-                                elm.appendChild(v2);
-                            }
-                        } else if (v instanceof HTMLElement) {
-                            elm.appendChild(v);
-                        } else {
-                            elm.innerHTML = v;
-                        }
-
-                    } else {
-                        v = obj[i];
-                        elm.setAttribute(i, v);
-                    }
-                }
-            }
-            r = elm;
-        }
-        return r;
-    };
 
     // モーダルウィンドウをセンターに寄せる
     function adjustCenter() {
@@ -217,14 +166,6 @@ function closeButton() {
         // モーダルウィンドウの基礎部分を作成
         var divid = 'modal';
 
-        var styleTag = {
-            'tag': 'style',
-            'content': ['\ndiv#modal{\n\tposition: fixed;\n\ttop:0;\n\tz-index:11;\n\twidth: 100%;\n\theight: 100%;' +
-            '\n\tbackground-color: transparent;}\ndiv#modal div#box-min{\n\tposition: relative;' +
-            '\n\tbackground-color:#ffffff;\n\twidth:500px;height:400px;\n\tborder:2px solid #666666;' +
-            '\n\tpadding:0 5px 0 5px;\n}\ndiv#box-min div.content{\n\t\n\toverflow: visible;\n}']
-        };
-
         // モーダルウィンドウのHTMLを格納
         var $weather = $('<div id=' + divid + ' class="box"><div id="box-min"><div id="header">' +
         '<h3>' + data.name + '　' + data.desc + '</h3>' +
@@ -240,8 +181,6 @@ function closeButton() {
         // モーダルウィンドウをHTMLに配置
         $('body').append($weather);
 
-        var style = domFromObject(styleTag);
-        $('#box-min').before(style);
         // モーダルウィンドウをセンターに
         adjustCenter();
 
@@ -305,7 +244,6 @@ function closeButton() {
             });
         });
     }
-
 
     var kintonePluginGranttChart = {
         lang: {
@@ -384,15 +322,19 @@ function closeButton() {
             var settingColors = JSON.parse(this.settings.config.settingColors || '{}');
             // Check multi field corlor and overide settingColors
             this.settings.config.settingColors = {};
+
+            function settingFieldClors(fieldColorArray, fieldColor) {
+                fieldColorArray.forEach(function(item) {
+                    var fieldColorOuput = item.trim();
+                    self.settings.config.settingColors[fieldColorOuput] = settingColors[fieldColor];
+                });
+            }
             for (var fieldColor in settingColors) {
                 if (!settingColors.hasOwnProperty(fieldColor)) {
                     continue;
                 }
                 var fieldColorArray = fieldColor.split(',');
-                fieldColorArray.forEach(function(item) {
-                    var fieldColorOuput = item.trim();
-                    self.settings.config.settingColors[fieldColorOuput] = settingColors[fieldColor];
-                });
+                settingFieldClors(fieldColorArray, fieldColor);
             }
         },
         getRecordsData: function(records, ganttBox, callbackFnc) {
@@ -416,7 +358,9 @@ function closeButton() {
             if (conf.fieldNameColor.indexOf('[Table]') === 0) {
                 tableFlg = true;
             }
-            if (tableFlg) {
+
+            // Create the record.
+            function createRecords1() {
                 for (var i2 = 0; i2 < records.length; i2++) {
                     var subTable = records[i2].Table.value;
 
@@ -437,31 +381,33 @@ function closeButton() {
                         }
 
                         var colorValue = subTable[j].value[GANTT_COLOR]['value'] || '';
+                        var fromValue = subTable[j].value[GANTT_FROM]['value'];
+                        var toValue = subTable[j].value[GANTT_TO]['value'];
                         if (colorValue && self.settings.config.settingColors[colorValue]) {
                             var styleRecordClass = self.settings.element.prefixColorGantt + 'class-' + i2 + '-' + j;
                             colorGantt = styleRecordClass;
                             ganttStylesRecord[styleRecordClass] = self.settings.config.settingColors[colorValue];
                         }
 
-                        if (subTable[j].value[GANTT_FROM]['value']) {
+                        if (fromValue) {
                             descGantt += '<div>' + conf.fieldNameFrom.slice(conf.fieldNameFrom.indexOf('[Table]') + 7) +
-                                ': ' + self.escapeHtml(self.convertDateTimeWithTimezone(subTable[j].value[GANTT_FROM]['value'])) +
-                                '</div>';
+                                ': ' + self.escapeHtml(self.convertDateTimeWithTimezone(fromValue)) + '</div>';
                         }
-                        if (subTable[j].value[GANTT_TO]['value']) {
+                        if (toValue) {
                             descGantt += '<div>' + conf.fieldNameTo.slice(conf.fieldNameTo.indexOf('[Table]') + 7) +
-                                ': ' + self.escapeHtml(self.convertDateTimeWithTimezone(subTable[j].value[GANTT_TO]['value'])) +
-                                '</div>';
+                                ': ' + self.escapeHtml(self.convertDateTimeWithTimezone(toValue)) + '</div>';
                         }
-                        if (subTable[j].value[GANTT_COLOR]['value']) {
+                        if (colorValue) {
                             descGantt += conf.fieldNameColor.slice(conf.fieldNameColor.indexOf('[Table]') + 7) +
-                            ': ' + self.escapeHtml(subTable[j].value[GANTT_COLOR]['value']);
+                            ': ' + self.escapeHtml(colorValue);
                         }
 
                         var ganttRecordData = {
                             id: self.escapeHtml(records[i2]['$id'].value),
                             name: (j !== 0) ? '' : self.escapeHtml(records[i2][GANTT_NAME].value),
-                            desc: subTable[j].value[GANTT_DESC] ? self.escapeHtml(subTable[j].value[GANTT_DESC].value) : '',
+                            desc:
+                                subTable[j].value[GANTT_DESC] ?
+                                    self.escapeHtml(subTable[j].value[GANTT_DESC].value) : '',
                             values: [{
                                 from: self.convertDateTime(subTable[j].value[GANTT_FROM].value),
                                 to: self.convertDateTime(subTable[j].value[GANTT_TO].value),
@@ -485,12 +431,11 @@ function closeButton() {
                             }]
                         };
                         self.data.push(ganttRecordData);
-
                     }
                 }
-            } else {
+            }
+            function createRecords2() {
                 for (var i3 = 0; i3 < records.length; i3++) {
-
                     var colorGantt2 = self.settings.element.classColorGanttDefault;
 
                     var colorValue2 = records[i3][GANTT_COLOR]['value'] || '';
@@ -506,18 +451,22 @@ function closeButton() {
                             self.escapeHtml(records[i3][GANTT_DESC]['value']) +
                             '</div>';
                     }
-                    if (records[i3][GANTT_FROM]['value']) {
+
+                    var fromValue2 = records[i3][GANTT_FROM]['value'];
+                    if (fromValue2) {
                         descGantt2 += '<div>' + conf.fieldNameFrom + ': ' +
-                            self.escapeHtml(self.convertDateTimeWithTimezone(records[i3][GANTT_FROM]['value'])) +
+                            self.escapeHtml(self.convertDateTimeWithTimezone(fromValue2)) +
                             '</div>';
                     }
-                    if (records[i3][GANTT_TO]['value']) {
+
+                    var toValue2 = records[i3][GANTT_TO]['value'];
+                    if (toValue2) {
                         descGantt2 += '<div>' + conf.fieldNameTo + ': ' +
-                            self.escapeHtml(self.convertDateTimeWithTimezone(records[i3][GANTT_TO]['value'])) +
+                            self.escapeHtml(self.convertDateTimeWithTimezone(toValue2)) +
                             '</div>';
                     }
-                    if (records[i3][GANTT_COLOR]['value']) {
-                        descGantt2 += conf.fieldNameColor + ': ' + self.escapeHtml(records[i3][GANTT_COLOR]['value']);
+                    if (colorValue2) {
+                        descGantt2 += conf.fieldNameColor + ': ' + self.escapeHtml(colorValue2);
                     }
                     var ganttRecordData2 = {
                         id: self.escapeHtml(records[i3]['$id'].value),
@@ -542,14 +491,21 @@ function closeButton() {
                                 'record': records[i3],
                                 'GANTT_FROM': GANTT_FROM,
                                 'GANTT_TO': GANTT_TO,
-                                'lang': this.lang[this.settings.i18n]
+                                'lang': self.lang[self.settings.i18n]
                             }
                         }]
                     };
                     self.data.push(ganttRecordData2);
                 }
             }
-            (typeof callbackFnc === 'function') && callbackFnc();
+            if (tableFlg) {
+                createRecords1();
+            } else {
+                createRecords2();
+            }
+            if (typeof callbackFnc === 'function') {
+                callbackFnc();
+            }
             self.uiSetStyleProcessBar(ganttStylesRecord);
         },
         gantt: function(elGantt) {


### PR DESCRIPTION
- cssのファイル差し替え
- ESLint対応
以下17件は除く
　no-loop-func, max-depth,max-nested-callbacks, max-len,
no-use-before-define(createTreeのみ)
- manifest.jsonのcss名変更