### PR TITLE
textConnct pluginバージョンアップ

### DIFF
--- a/examples/textConnect/config_css/51-modern-default.css
+++ b/examples/textConnect/config_css/51-modern-default.css
@@ -1,7 +1,6 @@
 @charset "UTF-8";
 /*
- * textConnect Plug-in
- * Copyright (c) 2016 Cybozu
+ * Copyright (c) 2014 Cybozu
  *
  * Licensed under the MIT License
 */
@@ -47,8 +46,7 @@
 <div class="kintoneplugin-row">Settings 2</div>
 */
 .kintoneplugin-row {
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 24px;
 }
 
 /* Title for settings*/
@@ -57,16 +55,14 @@
 <div class="kintoneplugin-label">Title</div>
 */
 .kintoneplugin-label {
-  margin: 1px 0 3px;
-  padding: 2px 6px;
-  border-bottom: 1px solid #d6d1cc;
-  border-left: 4px solid #989898;
+  margin-bottom: 8px;
+  font-weight: bold;
 }
 
-/* 設定項目の見出し */
+/* 設定項目名 */
 /* 項目 */
 /*
-<div class="kintoneplugin-label">設定項目の見出し</div>
+<div class="kintoneplugin-title">設定項目名</div>
 */
 .kintoneplugin-title {
   margin-bottom: 8px;
@@ -309,8 +305,6 @@
 */
 .kintoneplugin-select-outer {
   display: inline-block;
-  vertical-align: middle;
-
 }
 
 .kintoneplugin-select {
@@ -546,6 +540,116 @@
   cursor: pointer;
 }
 
-.plus{
-  padding-right: 8px;
+
+/* Table */
+/*
+<table class="kintoneplugin-table">
+  <thead>
+    <tr>
+      <th class="kintoneplugin-table-th"><span class="title">Title1</span></th>
+      <th class="kintoneplugin-table-th-blankspace"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <div class="kintoneplugin-table-td-control">
+          <div class="kintoneplugin-table-td-control-value">
+            <div class="kintoneplugin-input-outer">
+              <input class="kintoneplugin-input-text" type="text">
+            </div>
+          </div>
+        </div>
+      </td>
+      <td class="kintoneplugin-table-td-operation">
+        <button type="button" class="kintoneplugin-button-add-row-image" title="Add row"></button>
+        <button type="button" class="kintoneplugin-button-remove-row-image" title="Delete this row"></button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+*/
+.kintoneplugin-table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  margin-left: 18px;
+  margin-bottom: 16px;
+}
+
+.kintoneplugin-table-th {
+  border-color: #3498db;
+  height: 40px;
+  color: #fff;
+  box-sizing: border-box;
+  text-align: left;
+  font-weight: 400;
+  font-size: 12px;
+  white-space: nowrap;
+  border-width: 2px;
+  background-color: #3498db;
+}
+
+.kintoneplugin-table-th .title {
+  display: inline-block;
+  padding: 4px 8px;
+  box-sizing: border-box;
+  min-width: 204px;
+}
+
+.kintoneplugin-table-th-blankspace {
+  background-color: transparent;
+}
+
+.kintoneplugin-table td {
+  border-color: #e3e7e8;
+  border-style: solid;
+  border-width: 0 1px 1px 0;
+  vertical-align: top;
+  padding: 4px 0;
+}
+
+.kintoneplugin-table td:first-child {
+    border-left-width: 1px;
+}
+
+.kintoneplugin-table td.kintoneplugin-table-td-operation {
+  border-right: 0;
+  border-bottom: 0;
+}
+
+.kintoneplugin-table-td-control {
+  padding: 0 8px;
+}
+
+.kintoneplugin-table-td-control-value {
+  overflow: hidden;
+  padding: 4px 0;
+  min-height: 21px;
+  color: #333;
+  background-color: transparent;
+}
+
+.kintoneplugin-table-td-operation .kintoneplugin-button-add-row-image, .kintoneplugin-table-td-operation .kintoneplugin-button-remove-row-image {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+}
+
+.kintoneplugin-table-td-operation .kintoneplugin-button-add-row-image {
+  margin-left: 12px;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAABG0lEQVQ4ja2UMWrDUAyG31TIAUIO0cVbCMToHa0nyF4HqbtPkBPkAqEe/KQ4bclkCB06FDqoQ7Cb5j2/l1L/oMFY/pB+SzImoZzc1BZ1lpObpnKDsihLICkBubIohy4AuQKS0qIsk5DFajsBdAQo+0vIdQBJA+hosdpOgqD7h+c7S7yJQbwg3gSBgPz4J1DfuqNrkyHR2vswTPY5Ofip6mzqQDIfVVUTHpaXLVb/giFXxhhj5uvdLJGYhFmUw3y9mxlb1Jn/kj81Ikvy4X1T1FmwMkB+A+QWkFsgOamq9s/ILRC/Bisb1bPR/2ZszoDkBZC/bp6zc6uORtmAbslH281fV4OkSXjUAPLTIMjb1cg98zy6Vd2l7ecoom+t8LKwzLF7UgAAAABJRU5ErkJggg==) center center no-repeat;
+  border: 1px solid transparent;
+}
+.kintoneplugin-table-td-operation .kintoneplugin-button-add-row-image:hover {
+  cursor: pointer;
+}
+.kintoneplugin-table-td-operation .kintoneplugin-button-remove-row-image {
+  margin-left: 4px;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAABPUlEQVQ4ja2UvW6DMBDHUTMkK0vyQJXoxoaUB2nWxEorMcNgD/gOWbIii7GSJx6Bmdegq1lKF6CUAqYSJ/2HE8dP5/tyHIvFcbynlLpxHO9tsZPGGDsCgI+IrwBAOrW+zxg7WiFBEOwAwEPE6xAyVpqmNwDwgiDYTYIIIU+c8/MSZCzO+XkSyDl//g9oIO8XKEmSk+1pc0LEa5Ikpx4GAP5csFIqVEqFFqjfw8ZdGyrLsjDLMhvs0hX+sBS4EkYIIQeHUuqOP5Rl+WGMqYwxVV3Xn03TfHW+MaYqiuIx/odS6k5mJqV811pHWusoz3OW5znrfK11JKV8m8xs05rZurkS9tPNpTkTQtyFEPfVc9Zm522yAd2Sb7abw6vRXoVZSJqmN0R8mQWNdxUm7hkAXADA/1OjtdZd2n6OFuwblG9sdxWO0ggAAAAASUVORK5CYII=) center center no-repeat;
+  border: 1px solid transparent;
+}
+
+.kintoneplugin-table-td-operation .kintoneplugin-button-remove-row-image:hover {
+  cursor: pointer;
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAACi0lEQVQ4jZ2UT0hUQRzHp0uHDtFVk0QqTGtdddXVN/Pe7ubuuu3Me7sY2s1jRZcOQX+kQC+dkrr15xAIElhIEBSZloKHPHTMIlHS9r2ZNdvUNK1Evh3S1WVdNX/wuf1+H+bHzHcIyVET4ZoiJViLjLKrjmBtUtBrdpSetwVzE0L25JrLKBlkh6RgHZJTWwmGLDidk5x2qYhWvaXIidKQ5Gx0U8kGkoJBCfpTcXZpU5HNNS45+7WdaKNwJmZgJORtz1wtqhVKQSd3Klpj2tSRMg28NtzhdZlgHf8rUoJBCoZZy8B4Q+27+578fWQiXFMkOfu6W5kSFL8bA3hQUWwRJVhLdqMOZW7Daq/NKVaa6tFdV9ZJJKetGRLLgBOogENL4bAc0FI4QQ+UZUByipSpIylYP3EEa0vLIrWQfjcWeh5hOTGBP2OfshkfxfLkZ8zduw1HOwZlGZgSOuZjvgGiOL2Rlp2qg6yvxNzdDiwNvsJi3/Ns+l9gaaAX329eh2OcgDR1TJs6Zi3jDVFcuyA3rhnzwa4tRsKVj4S7IJuyAiRcB+Hox6HifticYrHRj7eBqh6SiHjLFGcLGRdgGVAxP1TMlwP/vx7BYEcpcCaEO+6j59Zi1L2bp5HgFPNxH2Ysw24tKcwjhBDyJaJVJ9OZ2xkOp1CCAc1BdFaXXMyI1CTXrkybOr6ZOuQOTpRcFY2E6540EbI3K+zvQ972pGBIWQaSpg6bU0i+/todTmFzioW4D2iux8eG2p6n5eUHcn5Dw4Gq6FhEG0qZOlZOBzAb8yG5GuqlRj/QHMSU0Me7akoub/mfpYXeI/uHfJXmM8318EPY2/sj7h+ctfS+4ZOex7dch8++9JTkbTb3FyHXv8RgEtykAAAAAElFTkSuQmCC) center center no-repeat;
 }

--- a/examples/textConnect/contents/setting.html
+++ b/examples/textConnect/contents/setting.html
@@ -9,56 +9,163 @@
     <label class="kintoneplugin-label">
         <span id ="container_label">結合する項目</span>
     </label><br >
-    <div class="kintoneplugin-row">結合する項目を選択してください。（最大5つまで）</div>
-    <div class="kintoneplugin-select-outer">
-      <div class="kintoneplugin-select">
-        <select name="select1" id= "select1">
-          <option value="">-----</option>
-        </select>
-      </div>
+    <div class="kintoneplugin-desc">結合する項目を選択してください。（最大5つまで）</div>
+    
+    <div class="kintoneplugin-row" id="row1">
+        <span class="num">①</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select1" id= "select1">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select2" id= "select2">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select3" id= "select3">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select4" id= "select4">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select5" id= "select5">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
     </div>
-    <span class="plus">＋</span>
-    <div class="kintoneplugin-select-outer">
-      <div class="kintoneplugin-select">
-        <select name="select2" id= "select2">
-          <option value="">-----</option>
-        </select>
-      </div>
+    <div class="kintoneplugin-row" id="row2">
+        <span class="num">②</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select6" id= "select6">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select7" id= "select7">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select8" id= "select8">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select9" id= "select9">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select10" id= "select10">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
     </div>
-    <span class="plus">＋</span>
-    <div class="kintoneplugin-select-outer">
-      <div class="kintoneplugin-select">
-        <select name="select3" id= "select3">
-          <option value="">-----</option>
-        </select>
-      </div>
+    <div class="kintoneplugin-row" id="row3">
+        <span class="num">③</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select11" id= "select11">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select12" id= "select12">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select13" id= "select13">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select14" id= "select14">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
+        <span class="plus">＋</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="select15" id= "select15">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>
     </div>
-    <span class="plus">＋</span>
-    <div class="kintoneplugin-select-outer">
-      <div class="kintoneplugin-select">
-        <select name="select4" id= "select4">
-          <option value="">-----</option>
-        </select>
-      </div>
-    </div>
-    <span class="plus">＋</span>
-   <div class="kintoneplugin-select-outer">
-      <div class="kintoneplugin-select">
-        <select name="select5" id= "select5">
-          <option value="">-----</option>
-        </select>
-      </div>
-    </div>
+    
 　　</div>
   <br >
   <div class="block">
     <label class="kintoneplugin-label">
         <span id ="container_label">項目間の記号</span>
     </label><br >
-    <div class="kintoneplugin-row">結合される項目の間に表示される記号を入力してください。<br >未選択の場合、各項目が直接結合されます。</div>
-      <div class="kintoneplugin-input-outer">
-          <input name="between" id= "between" class="kintoneplugin-input-text" type="text">
-      </div>
+    <div class="kintoneplugin-desc">結合される項目の間に表示される記号を入力してください。<br >未選択の場合、各項目が直接結合されます。</div>
+    <div class="kintoneplugin-row">
+        <span class="num">①</span>
+        <div class="kintoneplugin-input-outer">
+            <input name="between" id= "between1" class="kintoneplugin-input-text" type="text">
+        </div> 
+    </div>
+    
+    <div class="kintoneplugin-row">
+        <span class="num">②</span>
+        <div class="kintoneplugin-input-outer">
+            <input name="between" id= "between2" class="kintoneplugin-input-text" type="text">
+        </div> 
+    </div>
+    
+    <div class="kintoneplugin-row">
+        <span class="num">③</span>
+        <div class="kintoneplugin-input-outer">
+            <input name="between" id= "between3" class="kintoneplugin-input-text" type="text">
+        </div> 
+    </div>
+    
     </div>
   <br >
   <div class="block">
@@ -66,13 +173,36 @@
         <span id ="container_label">結合された文字列を表示する項目</span>
         <span class="kintoneplugin-require">*</span>
     </label><br >
-    <div class="kintoneplugin-row">結合された文字列を表示する項目を選択してください。</div>
-    <div class="kintoneplugin-select-outer">
-      <div class="kintoneplugin-select">
-        <select name="copyfield" id= "copyfield">
-          <option value="">-----</option>
-        </select>
-      </div>
+    <div class="kintoneplugin-desc">結合された文字列を表示する項目を選択してください。</div>
+    <div class="kintoneplugin-row">
+        <span class="num">①</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="copyfield" id= "copyfield1">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>  
+    </div>
+    <div class="kintoneplugin-row">
+        <span class="num">②</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="copyfield" id= "copyfield2">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>  
+    </div>
+    <div class="kintoneplugin-row">
+    <span class="num">③</span>
+        <div class="kintoneplugin-select-outer">
+          <div class="kintoneplugin-select">
+            <select name="copyfield" id= "copyfield3">
+              <option value="">-----</option>
+            </select>
+          </div>
+        </div>  
     </div>
   </div>
   <br >

--- a/examples/textConnect/manifest.json
+++ b/examples/textConnect/manifest.json
@@ -28,9 +28,9 @@
 
         ],
         "css": [
-                "config_css/config.css",
+                "config_css/51-modern-default.css",
                 "https://js.cybozu.com/sweetalert/v1.1.3/sweetalert.css"
         ],
-         "required_params": ["copyfield"]
+         "required_params": []
     }
 }


### PR DESCRIPTION
次の変更を行いました。
・config_css
　-旧UIのCSS(config.css)から新UIのCSS(51-modern-default.css)に変更

・config.js
　- HTML要素のクラス/IDの変更に応じた修正
　-旧プラグインからの設定を引き継ぐ処理を追加
　-文字結合項目を3つまで追加

・setting.html
　-設定項目を3つまで追加

・desktop.js
　-単純な一つ項目処理からforを使った3項目処理に変更
　-プラグイン設定していない場合の判断処理を追加

・manifest.json
　-必須項目パラメータの削除