### PR TITLE
APIdocument-3673 【jQuery 3 Up】ガントチャート

### DIFF
--- a/examples/ganttchart/js/desktop-ganttchart.js
+++ b/examples/ganttchart/js/desktop-ganttchart.js
@@ -5,7 +5,7 @@
  * Licensed under the MIT License
  */
 jQuery.noConflict();
-document.write('<script type="text/javascript" src="https://js.cybozu.com/jquery/2.1.3/jquery.min.js"></script>');
+document.write('<script type="text/javascript" src="https://js.cybozu.com/jquery/3.6.4/jquery.min.js"></script>');
 
 // ローディング画面を出す関数
 const setLoading = () => {

--- a/examples/ganttchart/manifest.json
+++ b/examples/ganttchart/manifest.json
@@ -22,15 +22,15 @@
       "js":[
          "https://js.cybozu.com/jquery/3.6.4/jquery.min.js",
          "https://js.cybozu.com/jquerygantt/20210106/jquery.fn.gantt.min.js",
-         "https://js.kintone.com/momentjs/2.14.1/moment.min.js",
-         "https://momentjs.com/downloads/moment-timezone-with-data.min.js",
-         "https://js.cybozu.com/jqueryui/1.12.1/jquery-ui.min.js",
+         "https://js.kintone.com/momentjs/2.30.1/moment.min.js",
+         "https://js.cybozu.com/moment-timezone/0.6.0/moment-timezone-with-data.min.js",
+         "https://js.cybozu.com/jquery-ui/1.14.2/jquery-ui.min.js",
          "js/jquery.ui.datepicker-ja.min.js",
          "js/desktop-ganttchart.js"
       ],
       "css":[
          "https://js.cybozu.com/jquerygantt/20210106/css/style.css",
-         "https://js.cybozu.com/jqueryui/1.12.1/themes/smoothness/jquery-ui.css",
+         "https://js.cybozu.com/jquery-ui/1.14.2/themes/smoothness/jquery-ui.css",
          "css/addin-style.css"
       ]
    },

--- a/examples/ganttchart/manifest.json
+++ b/examples/ganttchart/manifest.json
@@ -1,6 +1,6 @@
 {
    "manifest_version":1,
-   "version":"2.2.4",
+   "version":"2.2.5",
    "type":"APP",
    "name":{
       "ja":"ガントチャートプラグイン",
@@ -20,7 +20,7 @@
    },
    "desktop":{
       "js":[
-         "https://js.cybozu.com/jquery/2.1.3/jquery.min.js",
+         "https://js.cybozu.com/jquery/3.6.4/jquery.min.js",
          "https://js.cybozu.com/jquerygantt/20210106/jquery.fn.gantt.min.js",
          "https://js.kintone.com/momentjs/2.14.1/moment.min.js",
          "https://momentjs.com/downloads/moment-timezone-with-data.min.js",
@@ -36,13 +36,13 @@
    },
    "mobile":{
       "js":[
-         "https://js.cybozu.com/jquery/2.1.3/jquery.min.js"
+         "https://js.cybozu.com/jquery/3.6.4/jquery.min.js"
       ]
    },
    "config":{
       "html":"html/config.html",
       "js":[
-         "https://js.cybozu.com/jquery/2.1.3/jquery.min.js",
+         "https://js.cybozu.com/jquery/3.6.4/jquery.min.js",
          "https://js.kintone.com/jsrender/0.9.80/jsrender.min.js",
          "thirdparties/jqColorPicker.min.js",
          "js/config.js"


### PR DESCRIPTION
## 🎯 行ったこと

jQuery 2.1.3 → 3.6.4 にアップグレード
（プラグインのバージョンは v2.2.4 → v2.2.5）

## 🧐 確認したこと

N/A

## 🤔 相談したいこと

N/A

## 📎 関連する URL

[APIdocument-3673](https://bozuman.cybozu.com/k/15284/show#record=3673)